### PR TITLE
feat: add migration orchestration service

### DIFF
--- a/migration-tool/.gitignore
+++ b/migration-tool/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.env

--- a/migration-tool/README.md
+++ b/migration-tool/README.md
@@ -1,0 +1,87 @@
+# Bertel Migration Tool
+
+This package contains a lightweight ingestion service designed to receive heterogeneous establishment payloads, orchestrate their normalisation and dispatch the resulting entities to the unified Bertel database.
+
+The tool exposes an HTTP API as well as a monitoring dashboard that lets operators visualise the journey of each payload, observe which specialised agent handled which slice of data, and inspect eventual routing errors. Unhandled fragments can be escalated to an external webhook for manual triage.
+
+## Features
+
+- **FastAPI ingestion endpoint** receiving raw JSON payloads.
+- **Coordinator agent** that partitions payloads into semantic sections (identity, localisation, contact, amenities, schedule, media and legacy identifiers).
+- **Specialised agents** that transform their respective section and write to Supabase/PostgreSQL using the existing unified schema.
+- **In-memory telemetry log** that records every routing step and feeds the dashboard UI.
+- **Webhook notifications** whenever a fragment cannot be routed to a specialised agent.
+- **Dashboard UI** (available at `/`) with live updates of processed payloads, emitted records and potential failures.
+
+## Getting started
+
+### 1. Install dependencies
+
+```bash
+pip install -e .[dev]
+```
+
+### 2. Configure environment variables
+
+Create a `.env` file (or export the variables) with the credentials of your Supabase instance and the webhook endpoint used for escalation:
+
+```env
+MIGRATION_SUPABASE_URL=<https://your-project.supabase.co>
+MIGRATION_SUPABASE_SERVICE_KEY=<service_role_key>
+MIGRATION_WEBHOOK_URL=<https://your.webhook/endpoint>
+MIGRATION_DASHBOARD_RETENTION=200  # optional, number of events kept in memory
+```
+
+### 3. Launch the API server
+
+```bash
+uvicorn migration_tool.main:create_app --factory --reload --port 8090
+```
+
+The dashboard is exposed on [http://localhost:8090/](http://localhost:8090/). The ingestion endpoint is available at `POST /ingest`.
+
+### 4. Run the test-suite
+
+```bash
+pytest
+```
+
+## API overview
+
+- `POST /ingest`: submit a raw establishment payload (JSON). Returns the actions performed by each agent and the list of unresolved fragments.
+- `GET /events`: retrieve the latest telemetry entries.
+- `GET /agents`: list registered agents and the kind of payload slices they accept.
+- `GET /health`: simple health probe.
+- `GET /`: dashboard visualisation.
+
+## Architecture
+
+```
+migration_tool/
+├── agents/
+│   ├── base.py              # shared agent protocol
+│   ├── coordinator.py       # coordinator + partition logic
+│   ├── identity.py          # writes canonical establishment entries
+│   ├── location.py          # handles addresses & geospatial data
+│   ├── contact.py           # handles phone/mail/web & access info
+│   ├── amenities.py         # handles equipment/services tags
+│   └── media.py             # handles media galleries
+├── config.py                # settings sourced from env vars
+├── main.py                  # FastAPI application factory
+├── schemas.py               # pydantic models for I/O & context
+├── supabase_client.py       # safe Supabase wrapper
+├── telemetry.py             # in-memory event bus
+└── webhook.py               # async notifier for unresolved fragments
+```
+
+Specialised agents never alter the business meaning of the data. They solely adjust the structure (renaming fields, splitting arrays, converting coordinates) before persisting the records.
+
+## Development notes
+
+- The Supabase wrapper degrades gracefully when credentials are missing: operations are recorded as "skipped" within telemetry so the rest of the pipeline can still be exercised locally.
+- The dashboard uses progressive enhancement (vanilla JS + HTMX-style polling) to keep the stack lightweight. No additional build step is required.
+- Event retention is purely in-memory; for production usage you may want to plug a persistent backend (Redis, Postgres etc.).
+
+## License
+
+MIT

--- a/migration-tool/migration_tool/agents/amenities.py
+++ b/migration-tool/migration_tool/agents/amenities.py
@@ -1,0 +1,45 @@
+"""Amenity agent handling onsite services and equipment."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..schemas import AgentContext
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import Agent
+
+
+class AmenitiesAgent(Agent):
+    name = "amenities"
+    description = "Splits raw equipment/services into structured tags."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog) -> None:
+        super().__init__()
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = ["amenities", "equipment", "services"]
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        raw_values: List[str] = []
+        for key in ("amenities", "equipment", "services"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                raw_values.extend(value)
+            elif isinstance(value, str):
+                raw_values.extend([segment.strip() for segment in value.split(",") if segment.strip()])
+
+        tags = sorted(set(raw_values))
+        data = {
+            "object_id": payload.get("establishment_id"),
+            "tags": tags,
+        }
+        self.telemetry.record(
+            "agent.amenities.transform",
+            {"context": context.model_dump(), "payload": payload, "tags": tags},
+        )
+        response = await self.supabase.upsert("object_amenities", data, on_conflict="object_id")
+        return {"status": "ok", "operation": "upsert", "table": "object_amenities", "response": response}
+
+
+__all__ = ["AmenitiesAgent"]

--- a/migration-tool/migration_tool/agents/base.py
+++ b/migration-tool/migration_tool/agents/base.py
@@ -1,0 +1,32 @@
+"""Agent protocol."""
+
+from __future__ import annotations
+
+import abc
+from typing import Any, Dict, Iterable
+
+from ..schemas import AgentContext, AgentDescriptor
+
+
+class Agent(abc.ABC):
+    """Abstract base class for specialised agents."""
+
+    name: str = "agent"
+    description: str = ""
+
+    def __init__(self) -> None:
+        self.expected_fields: Iterable[str] = []
+
+    @abc.abstractmethod
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        """Handle a payload fragment and return a result dictionary."""
+
+    def descriptor(self) -> AgentDescriptor:
+        return AgentDescriptor(
+            name=self.name,
+            description=self.description,
+            expected_fields=list(self.expected_fields),
+        )
+
+
+__all__ = ["Agent"]

--- a/migration-tool/migration_tool/agents/contact.py
+++ b/migration-tool/migration_tool/agents/contact.py
@@ -1,0 +1,49 @@
+"""Contact agent responsible for communication channels."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..schemas import AgentContext
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import Agent
+
+
+class ContactAgent(Agent):
+    name = "contact"
+    description = "Formats contact information (phone, mail, website, social links)."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog) -> None:
+        super().__init__()
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = [
+            "phone",
+            "email",
+            "website",
+            "socials",
+            "booking_url",
+        ]
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        socials = payload.get("socials", {})
+        data = {
+            "object_id": payload.get("establishment_id"),
+            "phone": payload.get("phone"),
+            "email": payload.get("email"),
+            "website": payload.get("website"),
+            "booking_url": payload.get("booking_url"),
+            "facebook": socials.get("facebook"),
+            "instagram": socials.get("instagram"),
+            "twitter": socials.get("twitter"),
+        }
+        self.telemetry.record(
+            "agent.contact.transform",
+            {"context": context.model_dump(), "payload": payload, "data": data},
+        )
+        response = await self.supabase.upsert("object_contact", data, on_conflict="object_id")
+        return {"status": "ok", "operation": "upsert", "table": "object_contact", "response": response}
+
+
+__all__ = ["ContactAgent"]

--- a/migration-tool/migration_tool/agents/coordinator.py
+++ b/migration-tool/migration_tool/agents/coordinator.py
@@ -1,0 +1,148 @@
+"""Coordinator agent orchestrating the routing of payloads."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, Iterable, List, Tuple
+
+from ..schemas import AgentContext, RawEstablishmentPayload, RoutedFragment
+from ..telemetry import EventLog
+from ..webhook import WebhookNotifier
+from .amenities import AmenitiesAgent
+from .base import Agent
+from .contact import ContactAgent
+from .identity import IdentityAgent
+from .location import LocationAgent
+from .media import MediaAgent
+
+
+RECOGNISED_FIELDS = {
+    "identity": {
+        "establishment_id",
+        "establishment_name",
+        "category",
+        "subcategory",
+        "description",
+        "legacy_ids",
+    },
+    "location": {
+        "address_line1",
+        "address_line2",
+        "postal_code",
+        "city",
+        "country",
+        "latitude",
+        "longitude",
+        "coordinates",
+        "meeting_point",
+    },
+    "contact": {
+        "phone",
+        "email",
+        "website",
+        "booking_url",
+        "socials",
+    },
+    "amenities": {"amenities", "equipment", "services"},
+    "media": {"media", "photos", "videos"},
+}
+
+
+def partition_payload(payload: Dict[str, Any]) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Any]]:
+    """Partition the payload into recognised sections and leftovers."""
+
+    sections: Dict[str, Dict[str, Any]] = {key: {} for key in RECOGNISED_FIELDS}
+    leftovers: Dict[str, Any] = {}
+
+    for key, value in payload.items():
+        matched = False
+        for section, expected in RECOGNISED_FIELDS.items():
+            if key in expected:
+                sections[section][key] = value
+                matched = True
+                break
+        if not matched:
+            leftovers[key] = value
+
+    return sections, leftovers
+
+
+class Coordinator:
+    """Coordinate routing between specialised agents."""
+
+    def __init__(
+        self,
+        identity_agent: IdentityAgent,
+        location_agent: LocationAgent,
+        contact_agent: ContactAgent,
+        amenities_agent: AmenitiesAgent,
+        media_agent: MediaAgent,
+        webhook: WebhookNotifier,
+        telemetry: EventLog,
+    ) -> None:
+        self.agents: Dict[str, Agent] = {
+            "identity": identity_agent,
+            "location": location_agent,
+            "contact": contact_agent,
+            "amenities": amenities_agent,
+            "media": media_agent,
+        }
+        self.webhook = webhook
+        self.telemetry = telemetry
+
+    def descriptors(self) -> Iterable[Dict[str, Any]]:
+        for name, agent in self.agents.items():
+            yield agent.descriptor().model_dump()
+
+    async def handle(self, payload: RawEstablishmentPayload) -> Tuple[List[RoutedFragment], Dict[str, Any]]:
+        coordinator_id = str(uuid.uuid4())
+        payload_dict = payload.model_dump(by_alias=True)
+        sections, leftovers = partition_payload({**payload_dict, **payload.data})
+        context = AgentContext(coordinator_id=coordinator_id, source_payload=payload_dict)
+        fragments: List[RoutedFragment] = []
+
+        self.telemetry.record(
+            "coordinator.received",
+            {"coordinator_id": coordinator_id, "payload": payload_dict, "sections": sections, "leftovers": leftovers},
+        )
+
+        for name, agent in self.agents.items():
+            section_payload = sections.get(name, {})
+            if not section_payload:
+                continue
+
+            section_payload.setdefault("establishment_id", payload_dict.get("legacy_ids", [None])[0])
+            section_payload.setdefault("establishment_name", payload.establishment_name)
+            section_payload.setdefault("category", payload.establishment_category)
+            section_payload.setdefault("subcategory", payload.establishment_subcategory)
+            section_payload.setdefault("legacy_ids", payload.legacy_ids)
+
+            try:
+                result = await agent.handle(section_payload, context)
+                fragments.append(
+                    RoutedFragment(agent=name, status="processed", payload=section_payload, message=None)
+                )
+                self.telemetry.record(
+                    f"coordinator.agent.{name}",
+                    {"coordinator_id": coordinator_id, "payload": section_payload, "result": result},
+                )
+            except Exception as exc:
+                fragments.append(
+                    RoutedFragment(agent=name, status="error", payload=section_payload, message=str(exc))
+                )
+                self.telemetry.record(
+                    f"coordinator.agent_error.{name}",
+                    {"coordinator_id": coordinator_id, "payload": section_payload, "error": str(exc)},
+                )
+
+        if leftovers:
+            await self.webhook.notify({
+                "coordinator_id": coordinator_id,
+                "establishment": payload.establishment_name,
+                "unresolved": leftovers,
+            })
+
+        return fragments, leftovers
+
+
+__all__ = ["Coordinator", "partition_payload"]

--- a/migration-tool/migration_tool/agents/identity.py
+++ b/migration-tool/migration_tool/agents/identity.py
@@ -1,0 +1,47 @@
+"""Identity agent responsible for the canonical establishment record."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..schemas import AgentContext
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import Agent
+
+
+class IdentityAgent(Agent):
+    name = "identity"
+    description = "Creates or updates the canonical establishment entry."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog) -> None:
+        super().__init__()
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = [
+            "establishment_id",
+            "establishment_name",
+            "category",
+            "subcategory",
+            "description",
+            "legacy_ids",
+        ]
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        data = {
+            "object_id": payload.get("establishment_id"),
+            "name": payload.get("establishment_name"),
+            "category": payload.get("category"),
+            "subcategory": payload.get("subcategory"),
+            "description": payload.get("description"),
+            "legacy_ids": payload.get("legacy_ids"),
+        }
+        self.telemetry.record(
+            "agent.identity.transform",
+            {"context": context.model_dump(), "payload": payload, "data": data},
+        )
+        response = await self.supabase.upsert("object", data, on_conflict="object_id")
+        return {"status": "ok", "operation": "upsert", "table": "object", "response": response}
+
+
+__all__ = ["IdentityAgent"]

--- a/migration-tool/migration_tool/agents/location.py
+++ b/migration-tool/migration_tool/agents/location.py
@@ -1,0 +1,53 @@
+"""Location agent handling addresses and geospatial data."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..schemas import AgentContext
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import Agent
+
+
+class LocationAgent(Agent):
+    name = "location"
+    description = "Normalises addressing and coordinate data."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog) -> None:
+        super().__init__()
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = [
+            "address_line1",
+            "address_line2",
+            "postal_code",
+            "city",
+            "country",
+            "latitude",
+            "longitude",
+            "meeting_point",
+        ]
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        coordinates = payload.get("coordinates", {})
+        data = {
+            "object_id": payload.get("establishment_id"),
+            "address_line1": payload.get("address_line1"),
+            "address_line2": payload.get("address_line2"),
+            "postal_code": payload.get("postal_code"),
+            "city": payload.get("city"),
+            "country": payload.get("country"),
+            "latitude": coordinates.get("lat") or payload.get("latitude"),
+            "longitude": coordinates.get("lon") or payload.get("longitude"),
+            "meeting_point": payload.get("meeting_point"),
+        }
+        self.telemetry.record(
+            "agent.location.transform",
+            {"context": context.model_dump(), "payload": payload, "data": data},
+        )
+        response = await self.supabase.upsert("object_location", data, on_conflict="object_id")
+        return {"status": "ok", "operation": "upsert", "table": "object_location", "response": response}
+
+
+__all__ = ["LocationAgent"]

--- a/migration-tool/migration_tool/agents/media.py
+++ b/migration-tool/migration_tool/agents/media.py
@@ -1,0 +1,46 @@
+"""Media agent handling photos and videos."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..schemas import AgentContext
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import Agent
+
+
+class MediaAgent(Agent):
+    name = "media"
+    description = "Normalises media galleries and associated metadata."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog) -> None:
+        super().__init__()
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = ["media", "photos", "videos"]
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        media_items: List[Dict[str, Any]] = []
+        for key in ("media", "photos", "videos"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        media_items.append(item)
+                    elif isinstance(item, str):
+                        media_items.append({"url": item})
+
+        data = {
+            "object_id": payload.get("establishment_id"),
+            "items": media_items,
+        }
+        self.telemetry.record(
+            "agent.media.transform",
+            {"context": context.model_dump(), "payload": payload, "items": media_items},
+        )
+        response = await self.supabase.upsert("object_media", data, on_conflict="object_id")
+        return {"status": "ok", "operation": "upsert", "table": "object_media", "response": response}
+
+
+__all__ = ["MediaAgent"]

--- a/migration-tool/migration_tool/config.py
+++ b/migration-tool/migration_tool/config.py
@@ -1,0 +1,31 @@
+"""Application configuration."""
+
+from functools import lru_cache
+from typing import Optional
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Environment driven configuration."""
+
+    supabase_url: Optional[str] = None
+    supabase_service_key: Optional[str] = None
+    webhook_url: Optional[str] = None
+    dashboard_retention: int = 200
+
+    model_config = SettingsConfigDict(
+        env_prefix="MIGRATION_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+    )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return a cached instance of :class:`Settings`."""
+
+    return Settings()
+
+
+__all__ = ["Settings", "get_settings"]

--- a/migration-tool/migration_tool/main.py
+++ b/migration-tool/migration_tool/main.py
@@ -1,0 +1,97 @@
+"""FastAPI application factory."""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Dict
+
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from .agents.amenities import AmenitiesAgent
+from .agents.contact import ContactAgent
+from .agents.coordinator import Coordinator
+from .agents.identity import IdentityAgent
+from .agents.location import LocationAgent
+from .agents.media import MediaAgent
+from .config import Settings, get_settings
+from .schemas import IngestionResponse, RawEstablishmentPayload
+from .supabase_client import SupabaseService
+from .telemetry import EventLog
+from .webhook import WebhookNotifier
+
+
+def create_app(settings: Settings = Depends(get_settings)) -> FastAPI:
+    telemetry = EventLog(retention=settings.dashboard_retention)
+    supabase = SupabaseService(settings.supabase_url, settings.supabase_service_key, telemetry)
+    webhook = WebhookNotifier(settings.webhook_url, telemetry)
+
+    coordinator = Coordinator(
+        identity_agent=IdentityAgent(supabase, telemetry),
+        location_agent=LocationAgent(supabase, telemetry),
+        contact_agent=ContactAgent(supabase, telemetry),
+        amenities_agent=AmenitiesAgent(supabase, telemetry),
+        media_agent=MediaAgent(supabase, telemetry),
+        webhook=webhook,
+        telemetry=telemetry,
+    )
+
+    app = FastAPI(title="Bertel Migration Tool", version="0.1.0")
+
+    templates_path = pathlib.Path(__file__).parent / "templates"
+    static_path = pathlib.Path(__file__).parent / "static"
+    templates = Jinja2Templates(directory=str(templates_path))
+
+    app.mount("/static", StaticFiles(directory=str(static_path)), name="static")
+
+    @app.on_event("startup")
+    async def _startup() -> None:  # pragma: no cover - FastAPI lifecycle
+        telemetry.record("app.startup", {})
+
+    @app.get("/", response_class=HTMLResponse)
+    async def dashboard(request: Request) -> HTMLResponse:
+        return templates.TemplateResponse(
+            "dashboard.html",
+            {
+                "request": request,
+            },
+        )
+
+    @app.get("/health")
+    async def health() -> Dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/events")
+    async def events() -> Dict[str, object]:
+        return {"events": telemetry.snapshot()}
+
+    @app.get("/agents")
+    async def agents() -> Dict[str, object]:
+        return {"agents": list(coordinator.descriptors())}
+
+    @app.post("/ingest", response_model=IngestionResponse)
+    async def ingest(payload: RawEstablishmentPayload) -> IngestionResponse:
+        fragments, leftovers = await coordinator.handle(payload)
+        response = IngestionResponse(
+            establishment_name=payload.establishment_name,
+            routed_fragments=fragments,
+            unresolved_fragments=leftovers,
+        )
+        telemetry.record(
+            "coordinator.responded",
+            response.model_dump(),
+        )
+        return response
+
+    return app
+
+
+def run() -> None:  # pragma: no cover - convenience script
+    import uvicorn
+
+    uvicorn.run("migration_tool.main:create_app", factory=True, reload=False)
+
+
+__all__ = ["create_app", "run"]

--- a/migration-tool/migration_tool/schemas.py
+++ b/migration-tool/migration_tool/schemas.py
@@ -1,0 +1,63 @@
+"""Pydantic models shared across the application."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class RawEstablishmentPayload(BaseModel):
+    """Envelope received from external systems."""
+
+    establishment_name: str = Field(..., alias="name")
+    establishment_category: Optional[str] = Field(None, alias="category")
+    establishment_subcategory: Optional[str] = Field(None, alias="subcategory")
+    legacy_ids: Optional[List[str]] = None
+    data: Dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {
+        "populate_by_name": True,
+        "extra": "allow",
+    }
+
+
+class RoutedFragment(BaseModel):
+    """Fragment routed to a specialised agent."""
+
+    agent: str
+    status: str
+    message: Optional[str] = None
+    payload: Dict[str, Any]
+
+
+class IngestionResponse(BaseModel):
+    """Response returned to the caller of the ingestion endpoint."""
+
+    establishment_name: str
+    routed_fragments: List[RoutedFragment]
+    unresolved_fragments: Dict[str, Any]
+
+
+class AgentDescriptor(BaseModel):
+    """Describe an agent for the dashboard."""
+
+    name: str
+    description: str
+    expected_fields: List[str]
+
+
+class AgentContext(BaseModel):
+    """Context shared with agents while processing a payload."""
+
+    coordinator_id: str
+    source_payload: Dict[str, Any]
+
+
+__all__ = [
+    "RawEstablishmentPayload",
+    "RoutedFragment",
+    "IngestionResponse",
+    "AgentDescriptor",
+    "AgentContext",
+]

--- a/migration-tool/migration_tool/static/dashboard.js
+++ b/migration-tool/migration_tool/static/dashboard.js
@@ -1,0 +1,54 @@
+async function fetchJSON(url) {
+  const response = await fetch(url, { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}`);
+  }
+  return response.json();
+}
+
+function renderAgents(container, agents) {
+  container.innerHTML = "";
+  agents.forEach((agent) => {
+    const wrapper = document.createElement("article");
+    wrapper.classList.add("agent");
+    wrapper.innerHTML = `
+      <h3>${agent.name}</h3>
+      <p>${agent.description}</p>
+      <div>${agent.expected_fields
+        .map((field) => `<span class="tag">${field}</span>`)
+        .join("")}</div>
+    `;
+    container.appendChild(wrapper);
+  });
+}
+
+function renderEvents(container, events) {
+  container.innerHTML = "";
+  events.forEach((event) => {
+    const wrapper = document.createElement("article");
+    wrapper.classList.add("event");
+    wrapper.innerHTML = `
+      <div class="timestamp">${new Date(event.timestamp).toLocaleString()}</div>
+      <h3>${event.type}</h3>
+      <pre>${JSON.stringify(event.payload, null, 2)}</pre>
+    `;
+    container.appendChild(wrapper);
+  });
+}
+
+async function refresh() {
+  try {
+    const [agents, events] = await Promise.all([
+      fetchJSON("/agents"),
+      fetchJSON("/events"),
+    ]);
+
+    renderAgents(document.getElementById("agents"), agents.agents);
+    renderEvents(document.getElementById("events"), events.events);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+refresh();
+setInterval(refresh, 4000);

--- a/migration-tool/migration_tool/static/styles.css
+++ b/migration-tool/migration_tool/static/styles.css
@@ -1,0 +1,81 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  padding: 0 2rem 2rem;
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+}
+
+header {
+  padding: 2rem 0 1rem;
+}
+
+h1 {
+  margin: 0;
+  font-size: 2.4rem;
+}
+
+main {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 25px 50px -12px rgba(30, 64, 175, 0.35);
+  backdrop-filter: blur(12px);
+}
+
+.panel h2 {
+  margin-top: 0;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+  color: #38bdf8;
+}
+
+.tag {
+  display: inline-block;
+  margin: 0.2rem;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.15);
+  color: #bfdbfe;
+  font-size: 0.75rem;
+}
+
+.event {
+  margin-bottom: 1.2rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px dashed rgba(148, 163, 184, 0.3);
+}
+
+.event h3 {
+  margin: 0 0 0.3rem;
+  font-size: 1rem;
+}
+
+.event pre {
+  margin: 0.3rem 0 0;
+  background: rgba(15, 23, 42, 0.65);
+  padding: 0.8rem;
+  border-radius: 12px;
+  overflow-x: auto;
+  font-size: 0.75rem;
+}
+
+.timestamp {
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.7);
+}

--- a/migration-tool/migration_tool/supabase_client.py
+++ b/migration-tool/migration_tool/supabase_client.py
@@ -1,0 +1,69 @@
+"""Supabase wrapper that degrades gracefully when credentials are missing."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional
+
+from supabase import Client, create_client
+
+from .telemetry import EventLog
+
+
+class SupabaseService:
+    """Facade encapsulating Supabase interactions."""
+
+    def __init__(self, url: Optional[str], key: Optional[str], telemetry: EventLog):
+        self.telemetry = telemetry
+        self._client: Optional[Client] = None
+        if url and key:
+            self._client = create_client(url, key)
+            self.telemetry.record(
+                "supabase.connected",
+                {"url": url},
+            )
+        else:
+            self.telemetry.record(
+                "supabase.disabled",
+                {"reason": "missing credentials"},
+            )
+
+    @property
+    def client(self) -> Optional[Client]:
+        return self._client
+
+    async def upsert(self, table: str, data: Dict[str, Any], *, on_conflict: Optional[str] = None) -> Dict[str, Any]:
+        """Upsert data into a given table."""
+
+        if not self._client:
+            payload = {
+                "table": table,
+                "data": data,
+                "on_conflict": on_conflict,
+            }
+            self.telemetry.record("supabase.skipped", payload)
+            return {"status": "skipped", "reason": "no credentials", "payload": payload}
+
+        def _execute() -> Dict[str, Any]:
+            query = self._client.table(table).upsert(data)
+            if on_conflict:
+                query = query.on_conflict(on_conflict)
+            response = query.execute()
+            return getattr(response, "model_dump", lambda: response.__dict__)()
+
+        try:
+            result = await asyncio.to_thread(_execute)
+            self.telemetry.record(
+                "supabase.upsert",
+                {"table": table, "data": data, "on_conflict": on_conflict, "response": result},
+            )
+            return result
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self.telemetry.record(
+                "supabase.error",
+                {"table": table, "data": data, "error": str(exc)},
+            )
+            raise
+
+
+__all__ = ["SupabaseService"]

--- a/migration-tool/migration_tool/telemetry.py
+++ b/migration-tool/migration_tool/telemetry.py
@@ -1,0 +1,47 @@
+"""Simple in-memory telemetry store used by the dashboard."""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Deque, Dict, Iterable, List
+
+
+@dataclass(slots=True)
+class TelemetryEvent:
+    """Represent a single telemetry event."""
+
+    type: str
+    payload: Dict[str, Any]
+    timestamp: dt.datetime = field(default_factory=lambda: dt.datetime.now(dt.timezone.utc))
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "type": self.type,
+            "payload": self.payload,
+            "timestamp": self.timestamp.isoformat(),
+        }
+
+
+class EventLog:
+    """Fixed-size FIFO log of events."""
+
+    def __init__(self, retention: int = 200):
+        self._events: Deque[TelemetryEvent] = deque(maxlen=retention)
+
+    def record(self, event_type: str, payload: Dict[str, Any]) -> None:
+        self._events.appendleft(TelemetryEvent(type=event_type, payload=payload))
+
+    def bulk(self, events: Iterable[TelemetryEvent]) -> None:
+        for event in events:
+            self._events.appendleft(event)
+
+    def snapshot(self) -> List[Dict[str, Any]]:
+        return [event.as_dict() for event in self._events]
+
+    def clear(self) -> None:
+        self._events.clear()
+
+
+__all__ = ["EventLog", "TelemetryEvent"]

--- a/migration-tool/migration_tool/templates/dashboard.html
+++ b/migration-tool/migration_tool/templates/dashboard.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bertel Migration Dashboard</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Bertel Migration Dashboard</h1>
+      <p>Visualise incoming payloads, agent routing and unresolved fragments in real-time.</p>
+    </header>
+    <main>
+      <section class="panel" id="agents-panel">
+        <h2>Registered agents</h2>
+        <div id="agents"></div>
+      </section>
+      <section class="panel" id="events-panel">
+        <h2>Telemetry</h2>
+        <div id="events"></div>
+      </section>
+    </main>
+    <script src="/static/dashboard.js"></script>
+  </body>
+</html>

--- a/migration-tool/migration_tool/webhook.py
+++ b/migration-tool/migration_tool/webhook.py
@@ -1,0 +1,44 @@
+"""Webhook notifier used for unresolved fragments."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import httpx
+
+from .telemetry import EventLog
+
+
+class WebhookNotifier:
+    """Send asynchronous notifications to an external system."""
+
+    def __init__(self, url: Optional[str], telemetry: EventLog):
+        self.url = url
+        self.telemetry = telemetry
+        if not url:
+            self.telemetry.record(
+                "webhook.disabled",
+                {"reason": "missing url"},
+            )
+
+    async def notify(self, payload: Dict[str, Any]) -> None:
+        if not self.url:
+            self.telemetry.record("webhook.skipped", payload)
+            return
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(self.url, json=payload, timeout=10)
+                response.raise_for_status()
+                self.telemetry.record(
+                    "webhook.sent",
+                    {"payload": payload, "status_code": response.status_code},
+                )
+            except httpx.HTTPError as exc:  # pragma: no cover - network failure
+                self.telemetry.record(
+                    "webhook.error",
+                    {"payload": payload, "error": str(exc)},
+                )
+
+
+__all__ = ["WebhookNotifier"]

--- a/migration-tool/pyproject.toml
+++ b/migration-tool/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "bertel-migration-tool"
+version = "0.1.0"
+description = "Migration orchestrator and visualization tool for Bertel"
+authors = [{ name = "OTI du Sud" }]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.111.0",
+    "uvicorn[standard]>=0.30.1",
+    "pydantic>=2.7.1",
+    "pydantic-settings>=2.3.1",
+    "httpx>=0.27.0",
+    "supabase>=2.4.0"
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.2.0"]
+
+[project.scripts]
+bertel-migration-api = "migration_tool.main:run"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+

--- a/migration-tool/tests/test_partition.py
+++ b/migration-tool/tests/test_partition.py
@@ -1,0 +1,27 @@
+from migration_tool.agents.coordinator import RECOGNISED_FIELDS, partition_payload
+
+
+def test_partition_payload_groups_known_fields():
+    payload = {
+        "establishment_name": "Hotel Test",
+        "address_line1": "1 Rue du Test",
+        "city": "Testville",
+        "phone": "+33 123456789",
+        "amenities": ["wifi", "parking"],
+        "media": ["https://example.com/photo.jpg"],
+        "custom_field": "value",
+    }
+
+    sections, leftovers = partition_payload(payload)
+
+    assert sections["location"]["address_line1"] == "1 Rue du Test"
+    assert sections["location"]["city"] == "Testville"
+    assert sections["contact"]["phone"] == "+33 123456789"
+    assert sections["amenities"]["amenities"] == ["wifi", "parking"]
+    assert sections["media"]["media"] == ["https://example.com/photo.jpg"]
+    assert leftovers == {"custom_field": "value"}
+
+
+def test_recognised_fields_are_disjoint():
+    all_fields = [field for fields in RECOGNISED_FIELDS.values() for field in fields]
+    assert len(all_fields) == len(set(all_fields)), "Recognised fields should be unique"


### PR DESCRIPTION
## Summary
- add a dedicated `migration-tool` package exposing a FastAPI ingestion API and monitoring dashboard for payload routing
- implement coordinator and specialised agents that partition establishment payloads, normalise data and persist it through Supabase
- provide environment-driven configuration, graceful webhook/Supabase integrations, telemetry log, and unit tests for payload partitioning

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d504ebc14c83278e449f6c99fc54a2