### PR TITLE
feat: enable ai-driven routing for migration tool

### DIFF
--- a/migration-tool/.dockerignore
+++ b/migration-tool/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.pytest_cache/
+*.DS_Store
+.env
+.env.*
+.git
+.gitignore
+node_modules

--- a/migration-tool/.gitignore
+++ b/migration-tool/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.env

--- a/migration-tool/Dockerfile
+++ b/migration-tool/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1.7
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+# Install system deps for building python packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy dependency metadata first for better caching
+COPY pyproject.toml README.md ./
+COPY migration_tool ./migration_tool
+
+RUN pip install --upgrade pip \
+    && pip install .
+
+EXPOSE 8090
+
+CMD ["uvicorn", "migration_tool.main:create_app", "--factory", "--host", "0.0.0.0", "--port", "8090"]

--- a/migration-tool/README.md
+++ b/migration-tool/README.md
@@ -1,0 +1,110 @@
+# Bertel Migration Tool
+
+This package contains a lightweight ingestion service designed to receive heterogeneous establishment payloads, orchestrate their normalisation and dispatch the resulting entities to the unified Bertel database.
+
+The tool exposes an HTTP API as well as a monitoring dashboard that lets operators visualise the journey of each payload, observe which specialised agent handled which slice of data, and inspect eventual routing errors. Unhandled fragments can be escalated to an external webhook for manual triage.
+
+## Features
+
+- **FastAPI ingestion endpoint** receiving raw JSON payloads.
+- **LLM-aware coordinator** that analyses each incoming JSON document and dynamically assigns fields to the right specialised agent (identity, localisation, contact, amenities, media, etc.).
+- **AI-enabled specialised agents** that reshape their respective fragment with the help of the configured language model (or the built-in rule-based fallback) before writing to Supabase/PostgreSQL using the DLL schema published in `Base de donnée DLL et API/`.
+- **In-memory telemetry log** that records every routing step and feeds the dashboard UI.
+- **Webhook notifications** whenever a fragment cannot be routed to a specialised agent.
+- **Dashboard UI** (available at `/`) with live updates of processed payloads, emitted records and potential failures.
+
+## Getting started
+
+### 1. Install dependencies
+
+```bash
+pip install -e .[dev]
+```
+
+### 2. Configure environment variables
+
+Create a `.env` file (or export the variables) with the credentials of your Supabase instance and the webhook endpoint used for escalation:
+
+```env
+MIGRATION_SUPABASE_URL=<https://your-project.supabase.co>
+MIGRATION_SUPABASE_SERVICE_KEY=<service_role_key>
+MIGRATION_WEBHOOK_URL=<https://your.webhook/endpoint>
+MIGRATION_DASHBOARD_RETENTION=200          # optional, number of events kept in memory
+MIGRATION_AI_PROVIDER=auto                 # "auto" (default), "rule" or "openai"
+MIGRATION_AI_MODEL=gpt-4o-mini             # model name when using OpenAI
+MIGRATION_OPENAI_API_KEY=sk-...            # required if MIGRATION_AI_PROVIDER=openai
+```
+
+### 3. Launch the API server
+
+```bash
+uvicorn migration_tool.main:create_app --factory --reload --port 8090
+```
+
+The dashboard is exposed on [http://localhost:8090/](http://localhost:8090/). The ingestion endpoint is available at `POST /ingest`.
+
+### 4. Run the test-suite
+
+```bash
+pytest
+```
+
+### 5. Containerised usage
+
+You can run the ingestion stack through Docker without installing any local Python dependencies.
+
+1. Create a `.env` file next to `docker-compose.yml` (reuse the variables from step 2).
+2. Build and start the stack:
+
+   ```bash
+   docker compose up --build
+   ```
+
+   The API will be available on [http://localhost:8090](http://localhost:8090). The same container serves the dashboard UI.
+
+3. To stop the services:
+
+   ```bash
+   docker compose down
+   ```
+
+## API overview
+
+- `POST /ingest`: submit a raw establishment payload (JSON). Returns the actions performed by each agent and the list of unresolved fragments.
+- `GET /events`: retrieve the latest telemetry entries.
+- `GET /agents`: list registered agents and the kind of payload slices they accept.
+- `GET /health`: simple health probe.
+- `GET /`: dashboard visualisation.
+
+## Architecture
+
+```
+migration_tool/
+├── agents/
+│   ├── base.py              # shared agent protocol
+│   ├── coordinator.py       # coordinator + semantic routing
+│   ├── identity.py          # writes canonical establishment entries
+│   ├── location.py          # handles addresses & geospatial data
+│   ├── contact.py           # handles phone/mail/web & access info
+│   ├── amenities.py         # handles equipment/services tags
+│   └── media.py             # handles media galleries
+├── ai.py                    # LLM abstractions, rule-based fallback & router
+├── config.py                # settings sourced from env vars
+├── main.py                  # FastAPI application factory
+├── schemas.py               # pydantic models for I/O & context
+├── supabase_client.py       # safe Supabase wrapper
+├── telemetry.py             # in-memory event bus
+└── webhook.py               # async notifier for unresolved fragments
+```
+
+Specialised agents never alter the business meaning of the data. They solely adjust the structure (renaming fields, splitting arrays, converting coordinates) before persisting the records.
+
+## Development notes
+
+- The Supabase wrapper degrades gracefully when credentials are missing: operations are recorded as "skipped" within telemetry so the rest of the pipeline can still be exercised locally.
+- The dashboard uses progressive enhancement (vanilla JS + HTMX-style polling) to keep the stack lightweight. No additional build step is required.
+- Event retention is purely in-memory; for production usage you may want to plug a persistent backend (Redis, Postgres etc.).
+
+## License
+
+MIT

--- a/migration-tool/docker-compose.yml
+++ b/migration-tool/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  migration-tool:
+    build: .
+    ports:
+      - "8090:8090"
+    env_file:
+      - .env
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8090/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/migration-tool/migration_tool/agents/amenities.py
+++ b/migration-tool/migration_tool/agents/amenities.py
@@ -1,0 +1,58 @@
+"""Amenity agent handling onsite services and equipment."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..ai import LLMClient
+from ..schemas import AgentContext, AmenityLinkRecord, AmenityTransformation
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import AIEnabledAgent
+
+
+class AmenitiesAgent(AIEnabledAgent):
+    name = "amenities"
+    description = "Splits raw equipment/services into structured tags."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog, llm: LLMClient) -> None:
+        super().__init__(llm)
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = ["amenities", "equipment", "services"]
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        transformation = await self.llm.transform_fragment(
+            agent_name=self.name,
+            payload=payload,
+            response_model=AmenityTransformation,
+        )
+        amenities: List[AmenityLinkRecord] = transformation.amenities
+        self.telemetry.record(
+            "agent.amenities.transform",
+            {
+                "context": context.model_dump(),
+                "payload": payload,
+                "amenities": [amenity.model_dump() for amenity in amenities],
+            },
+        )
+        responses = []
+        for amenity in amenities:
+            amenity_id = await self.supabase.lookup("ref_amenity", code=amenity.amenity_code)
+            data = amenity.to_supabase(amenity_id=amenity_id)
+            responses.append(
+                await self.supabase.upsert(
+                    "object_amenity",
+                    data,
+                    on_conflict="object_id,amenity_id",
+                )
+            )
+        return {
+            "status": "ok",
+            "operation": "upsert",
+            "table": "object_amenity",
+            "responses": responses,
+        }
+
+
+__all__ = ["AmenitiesAgent"]

--- a/migration-tool/migration_tool/agents/base.py
+++ b/migration-tool/migration_tool/agents/base.py
@@ -1,0 +1,41 @@
+"""Agent protocol."""
+
+from __future__ import annotations
+
+import abc
+from typing import Any, Dict, Iterable
+
+from ..schemas import AgentContext, AgentDescriptor
+from ..ai import LLMClient
+
+
+class Agent(abc.ABC):
+    """Abstract base class for specialised agents."""
+
+    name: str = "agent"
+    description: str = ""
+
+    def __init__(self) -> None:
+        self.expected_fields: Iterable[str] = []
+
+    @abc.abstractmethod
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        """Handle a payload fragment and return a result dictionary."""
+
+    def descriptor(self) -> AgentDescriptor:
+        return AgentDescriptor(
+            name=self.name,
+            description=self.description,
+            expected_fields=list(self.expected_fields),
+        )
+
+
+class AIEnabledAgent(Agent):
+    """Agent variant enriched with an LLM client."""
+
+    def __init__(self, llm: LLMClient) -> None:
+        super().__init__()
+        self.llm = llm
+
+
+__all__ = ["Agent", "AIEnabledAgent"]

--- a/migration-tool/migration_tool/agents/contact.py
+++ b/migration-tool/migration_tool/agents/contact.py
@@ -1,0 +1,63 @@
+"""Contact agent responsible for communication channels."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..ai import LLMClient
+from ..schemas import AgentContext, ContactChannelRecord, ContactTransformation
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import AIEnabledAgent
+
+
+class ContactAgent(AIEnabledAgent):
+    name = "contact"
+    description = "Formats contact information (phone, mail, website, social links)."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog, llm: LLMClient) -> None:
+        super().__init__(llm)
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = [
+            "phone",
+            "email",
+            "website",
+            "socials",
+            "booking_url",
+        ]
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        transformation = await self.llm.transform_fragment(
+            agent_name=self.name,
+            payload=payload,
+            response_model=ContactTransformation,
+        )
+        channels: List[ContactChannelRecord] = transformation.channels
+        self.telemetry.record(
+            "agent.contact.transform",
+            {
+                "context": context.model_dump(),
+                "payload": payload,
+                "channels": [channel.model_dump() for channel in channels],
+            },
+        )
+        responses = []
+        for channel in channels:
+            if not channel.value:
+                continue
+            kind_id = await self.supabase.lookup("ref_code_contact_kind", code=channel.kind_code)
+            role_id = None
+            if channel.role_code:
+                role_id = await self.supabase.lookup("ref_contact_role", code=channel.role_code)
+            data = channel.to_supabase(kind_id=kind_id, role_id=role_id)
+            responses.append(await self.supabase.upsert("contact_channel", data))
+        return {
+            "status": "ok",
+            "operation": "upsert",
+            "table": "contact_channel",
+            "responses": responses,
+        }
+
+
+__all__ = ["ContactAgent"]

--- a/migration-tool/migration_tool/agents/coordinator.py
+++ b/migration-tool/migration_tool/agents/coordinator.py
@@ -1,0 +1,114 @@
+"""Coordinator agent orchestrating the routing of payloads."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, Iterable, List
+
+from ..ai import FieldRouter
+from ..schemas import (
+    AgentContext,
+    FieldRoutingDecision,
+    RawEstablishmentPayload,
+    RoutedFragment,
+)
+from ..telemetry import EventLog
+from ..webhook import WebhookNotifier
+from .amenities import AmenitiesAgent
+from .base import Agent
+from .contact import ContactAgent
+from .identity import IdentityAgent
+from .location import LocationAgent
+from .media import MediaAgent
+
+
+class Coordinator:
+    """Coordinate routing between specialised agents."""
+
+    def __init__(
+        self,
+        identity_agent: IdentityAgent,
+        location_agent: LocationAgent,
+        contact_agent: ContactAgent,
+        amenities_agent: AmenitiesAgent,
+        media_agent: MediaAgent,
+        webhook: WebhookNotifier,
+        telemetry: EventLog,
+        router: FieldRouter,
+    ) -> None:
+        self.agents: Dict[str, Agent] = {
+            "identity": identity_agent,
+            "location": location_agent,
+            "contact": contact_agent,
+            "amenities": amenities_agent,
+            "media": media_agent,
+        }
+        self.webhook = webhook
+        self.telemetry = telemetry
+        self.router = router
+
+    def descriptors(self) -> Iterable[Dict[str, Any]]:
+        for name, agent in self.agents.items():
+            yield agent.descriptor().model_dump()
+
+    async def handle(self, payload: RawEstablishmentPayload) -> tuple[List[RoutedFragment], Dict[str, Any]]:
+        coordinator_id = str(uuid.uuid4())
+        payload_dict = payload.model_dump(by_alias=True)
+        combined_payload = {**payload_dict, **payload.data}
+        decision: FieldRoutingDecision = await self.router.route(
+            payload=combined_payload,
+            agent_descriptors=[agent.descriptor() for agent in self.agents.values()],
+        )
+        context = AgentContext(coordinator_id=coordinator_id, source_payload=payload_dict)
+        fragments: List[RoutedFragment] = []
+
+        self.telemetry.record(
+            "coordinator.received",
+            {
+                "coordinator_id": coordinator_id,
+                "payload": payload_dict,
+                "decision": decision.model_dump(),
+            },
+        )
+
+        for name, agent in self.agents.items():
+            section_payload = dict(decision.sections.get(name, {}))
+            if not section_payload:
+                continue
+
+            section_payload.setdefault("establishment_id", payload_dict.get("legacy_ids", [None])[0])
+            section_payload.setdefault("establishment_name", payload.establishment_name)
+            section_payload.setdefault("category", payload.establishment_category)
+            section_payload.setdefault("subcategory", payload.establishment_subcategory)
+            section_payload.setdefault("legacy_ids", payload.legacy_ids)
+
+            try:
+                result = await agent.handle(section_payload, context)
+                fragments.append(
+                    RoutedFragment(agent=name, status="processed", payload=section_payload, message=None)
+                )
+                self.telemetry.record(
+                    f"coordinator.agent.{name}",
+                    {"coordinator_id": coordinator_id, "payload": section_payload, "result": result},
+                )
+            except Exception as exc:
+                fragments.append(
+                    RoutedFragment(agent=name, status="error", payload=section_payload, message=str(exc))
+                )
+                self.telemetry.record(
+                    f"coordinator.agent_error.{name}",
+                    {"coordinator_id": coordinator_id, "payload": section_payload, "error": str(exc)},
+                )
+
+        leftovers = decision.leftovers
+        if leftovers:
+            await self.webhook.notify({
+                "coordinator_id": coordinator_id,
+                "establishment": payload.establishment_name,
+                "unresolved": leftovers,
+            })
+
+        return fragments, leftovers
+
+
+__all__ = ["Coordinator"]

--- a/migration-tool/migration_tool/agents/identity.py
+++ b/migration-tool/migration_tool/agents/identity.py
@@ -1,0 +1,51 @@
+"""Identity agent responsible for the canonical establishment record."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..ai import LLMClient
+from ..schemas import AgentContext, IdentityRecord
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import AIEnabledAgent
+
+
+class IdentityAgent(AIEnabledAgent):
+    name = "identity"
+    description = "Creates or updates the canonical establishment entry."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog, llm: LLMClient) -> None:
+        super().__init__(llm)
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = [
+            "establishment_id",
+            "establishment_name",
+            "category",
+            "subcategory",
+            "description",
+            "legacy_ids",
+        ]
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        record = await self.llm.transform_fragment(
+            agent_name=self.name,
+            payload=payload,
+            response_model=IdentityRecord,
+        )
+        data = record.to_supabase()
+        self.telemetry.record(
+            "agent.identity.transform",
+            {"context": context.model_dump(), "payload": payload, "record": record.model_dump(), "data": data},
+        )
+        response = await self.supabase.upsert("object", data, on_conflict="id")
+        return {
+            "status": "ok",
+            "operation": "upsert",
+            "table": "object",
+            "response": response,
+        }
+
+
+__all__ = ["IdentityAgent"]

--- a/migration-tool/migration_tool/agents/location.py
+++ b/migration-tool/migration_tool/agents/location.py
@@ -1,0 +1,63 @@
+"""Location agent handling addresses and geospatial data."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..ai import LLMClient
+from ..schemas import AgentContext, LocationRecord, LocationTransformation
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import AIEnabledAgent
+
+
+class LocationAgent(AIEnabledAgent):
+    name = "location"
+    description = "Normalises addressing and coordinate data."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog, llm: LLMClient) -> None:
+        super().__init__(llm)
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = [
+            "address_line1",
+            "address_line2",
+            "postal_code",
+            "city",
+            "country",
+            "latitude",
+            "longitude",
+            "meeting_point",
+        ]
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        transformation = await self.llm.transform_fragment(
+            agent_name=self.name,
+            payload=payload,
+            response_model=LocationTransformation,
+        )
+        locations: List[LocationRecord] = transformation.locations
+        self.telemetry.record(
+            "agent.location.transform",
+            {
+                "context": context.model_dump(),
+                "payload": payload,
+                "locations": [record.model_dump() for record in locations],
+            },
+        )
+        responses = []
+        for record in locations:
+            if not record.object_id:
+                continue
+            responses.append(
+                await self.supabase.upsert("object_location", record.to_supabase())
+            )
+        return {
+            "status": "ok",
+            "operation": "upsert",
+            "table": "object_location",
+            "responses": responses,
+        }
+
+
+__all__ = ["LocationAgent"]

--- a/migration-tool/migration_tool/agents/media.py
+++ b/migration-tool/migration_tool/agents/media.py
@@ -1,0 +1,58 @@
+"""Media agent handling photos and videos."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..ai import LLMClient
+from ..schemas import AgentContext, MediaRecord, MediaTransformation
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import AIEnabledAgent
+
+
+class MediaAgent(AIEnabledAgent):
+    name = "media"
+    description = "Normalises media galleries and associated metadata."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog, llm: LLMClient) -> None:
+        super().__init__(llm)
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = ["media", "photos", "videos"]
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        transformation = await self.llm.transform_fragment(
+            agent_name=self.name,
+            payload=payload,
+            response_model=MediaTransformation,
+        )
+        media: List[MediaRecord] = transformation.media
+        self.telemetry.record(
+            "agent.media.transform",
+            {
+                "context": context.model_dump(),
+                "payload": payload,
+                "media": [item.model_dump() for item in media],
+            },
+        )
+        responses = []
+        for item in media:
+            if not item.url:
+                continue
+            media_type_id = await self.supabase.lookup("ref_code_media_type", code=item.media_type_code)
+            responses.append(
+                await self.supabase.upsert(
+                    "media",
+                    item.to_supabase(media_type_id=media_type_id),
+                )
+            )
+        return {
+            "status": "ok",
+            "operation": "upsert",
+            "table": "media",
+            "responses": responses,
+        }
+
+
+__all__ = ["MediaAgent"]

--- a/migration-tool/migration_tool/ai.py
+++ b/migration-tool/migration_tool/ai.py
@@ -1,0 +1,550 @@
+"""Lightweight AI abstractions for field classification and transformation."""
+
+from __future__ import annotations
+
+import abc
+import json
+import re
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from pydantic import BaseModel
+
+from .schemas import (
+    AgentDescriptor,
+    AmenityLinkRecord,
+    AmenityTransformation,
+    ContactChannelRecord,
+    ContactTransformation,
+    FieldAssignment,
+    FieldRoutingDecision,
+    IdentityRecord,
+    LocationRecord,
+    LocationTransformation,
+    MediaRecord,
+    MediaTransformation,
+)
+
+try:  # pragma: no cover - optional dependency
+    from openai import AsyncOpenAI
+except Exception:  # pragma: no cover - optional dependency
+    AsyncOpenAI = None  # type: ignore
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", text.lower()).strip("_")
+
+
+class LLMClient(abc.ABC):
+    """Abstract interface for semantic helpers."""
+
+    name: str
+
+    @abc.abstractmethod
+    async def classify_fields(
+        self,
+        *,
+        payload: Dict[str, Any],
+        agent_descriptors: Sequence[AgentDescriptor],
+    ) -> FieldRoutingDecision:
+        """Return routing information for payload fields."""
+
+    @abc.abstractmethod
+    async def transform_fragment(
+        self,
+        *,
+        agent_name: str,
+        payload: Dict[str, Any],
+        response_model: type[BaseModel],
+    ) -> BaseModel:
+        """Return a structured representation for a fragment."""
+
+
+class RuleBasedLLM(LLMClient):
+    """Heuristic backed fallback when no external model is configured."""
+
+    name = "rule-based"
+
+    FIELD_KEYWORDS: Dict[str, Iterable[str]] = {
+        "identity": ("name", "title", "category", "sub_category", "legacy", "description", "type"),
+        "location": ("address", "postal", "zip", "city", "country", "latitude", "longitude", "gps", "insee"),
+        "contact": ("phone", "email", "website", "url", "booking", "contact", "social"),
+        "amenities": ("amenitie", "equipment", "service", "facility"),
+        "media": ("photo", "image", "video", "media", "picture", "logo"),
+    }
+
+    CATEGORY_TO_OBJECT_TYPE: Dict[str, str] = {
+        "hotel": "HOT",
+        "hébergement": "HLO",
+        "lodging": "HLO",
+        "restaurant": "RES",
+        "food": "RES",
+        "activity": "ASC",
+        "visite": "LOI",
+        "event": "FMA",
+        "événement": "FMA",
+        "shop": "COM",
+        "commerce": "COM",
+        "itinéraire": "ITI",
+        "itinerary": "ITI",
+        "organization": "ORG",
+        "office": "ORG",
+    }
+
+    CONTACT_KIND_DEFAULTS: Dict[str, str] = {
+        "phone": "phone",
+        "mobile": "phone",
+        "téléphone": "phone",
+        "email": "email",
+        "mail": "email",
+        "website": "website",
+        "site": "website",
+        "booking": "booking",
+        "reservation": "booking",
+        "facebook": "facebook",
+        "instagram": "instagram",
+        "twitter": "twitter",
+        "x": "twitter",
+        "tiktok": "tiktok",
+        "youtube": "youtube",
+        "whatsapp": "whatsapp",
+    }
+
+    MEDIA_TYPE_DEFAULTS: Dict[str, str] = {
+        "image": "image",
+        "photo": "image",
+        "picture": "image",
+        "logo": "logo",
+        "video": "video",
+    }
+
+    async def classify_fields(
+        self,
+        *,
+        payload: Dict[str, Any],
+        agent_descriptors: Sequence[AgentDescriptor],
+    ) -> FieldRoutingDecision:
+        assignments: List[FieldAssignment] = []
+        leftovers: Dict[str, Any] = {}
+
+        available_agents = {descriptor.name for descriptor in agent_descriptors}
+
+        for key, value in payload.items():
+            agent_name = self._guess_agent(key, value, available_agents)
+            if agent_name is None:
+                leftovers[key] = value
+                continue
+
+            target_attribute = self._normalize_attribute(agent_name, key)
+            reasoning = f"Matched keyword for {agent_name}"
+            assignments.append(
+                FieldAssignment(
+                    field_name=key,
+                    agent=agent_name,
+                    target_attribute=target_attribute,
+                    reasoning=reasoning,
+                )
+            )
+
+        return FieldRoutingDecision(assignments=assignments, leftovers=leftovers)
+
+    async def transform_fragment(
+        self,
+        *,
+        agent_name: str,
+        payload: Dict[str, Any],
+        response_model: type[BaseModel],
+    ) -> BaseModel:
+        if agent_name == "identity":
+            data = self._transform_identity(payload)
+        elif agent_name == "location":
+            data = self._transform_location(payload)
+        elif agent_name == "contact":
+            data = self._transform_contact(payload)
+        elif agent_name == "amenities":
+            data = self._transform_amenities(payload)
+        elif agent_name == "media":
+            data = self._transform_media(payload)
+        else:
+            raise ValueError(f"Unknown agent '{agent_name}' for rule based transformation")
+
+        if isinstance(data, response_model):
+            return data
+        return response_model.model_validate(data)
+
+    def _guess_agent(
+        self,
+        key: str,
+        value: Any,
+        available_agents: Iterable[str],
+    ) -> Optional[str]:
+        lowered = key.lower()
+        for agent_name, keywords in self.FIELD_KEYWORDS.items():
+            if agent_name not in available_agents:
+                continue
+            if any(keyword in lowered for keyword in keywords):
+                return agent_name
+
+        # fallbacks based on value shape
+        if isinstance(value, dict) and "contact" in available_agents:
+            return "contact"
+        if isinstance(value, (list, tuple)):
+            if value and isinstance(value[0], dict):
+                if "media" in available_agents:
+                    return "media"
+                if "amenities" in available_agents:
+                    return "amenities"
+        return None
+
+    def _normalize_attribute(self, agent_name: str, field: str) -> str:
+        mapping = {
+            "identity": {
+                "establishment_name": "name",
+                "legacy_ids": "legacy_ids",
+                "establishment_id": "object_id",
+            },
+            "location": {
+                "address_line1": "address1",
+                "address_line2": "address2",
+                "postal_code": "postcode",
+                "zip": "postcode",
+            },
+        }
+        if agent_name in mapping and field in mapping[agent_name]:
+            return mapping[agent_name][field]
+        return _normalize(field)
+
+    def _transform_identity(self, payload: Dict[str, Any]) -> IdentityRecord:
+        name = payload.get("establishment_name") or payload.get("name")
+        if not name:
+            raise ValueError("Identity payload is missing a name")
+
+        category = payload.get("category") or payload.get("establishment_category")
+        subcategory = payload.get("subcategory") or payload.get("establishment_subcategory")
+        object_type = self._guess_object_type(category or "")
+        legacy_ids = payload.get("legacy_ids") or []
+        if isinstance(legacy_ids, str):
+            legacy_ids = [legacy_ids]
+
+        description = payload.get("description") or payload.get("summary")
+
+        record = IdentityRecord(
+            object_id=payload.get("establishment_id") or payload.get("object_id"),
+            object_type=object_type,
+            name=name,
+            description=description,
+            category_code=self._normalize_category(category),
+            subcategory_code=self._normalize_category(subcategory),
+            legacy_ids=legacy_ids,
+            source_extra={key: value for key, value in payload.items() if key not in {"establishment_name", "description"}},
+        )
+        return record
+
+    def _transform_location(self, payload: Dict[str, Any]) -> LocationTransformation:
+        latitude = self._coerce_float(payload.get("latitude"))
+        longitude = self._coerce_float(payload.get("longitude"))
+        coordinates = payload.get("coordinates")
+        if coordinates and (latitude is None or longitude is None):
+            if isinstance(coordinates, dict):
+                latitude = latitude or self._coerce_float(coordinates.get("lat"))
+                longitude = longitude or self._coerce_float(coordinates.get("lon") or coordinates.get("lng"))
+            elif isinstance(coordinates, (list, tuple)) and len(coordinates) >= 2:
+                latitude = latitude or self._coerce_float(coordinates[0])
+                longitude = longitude or self._coerce_float(coordinates[1])
+
+        record = LocationRecord(
+            object_id=payload.get("establishment_id") or payload.get("object_id") or payload.get("legacy_id"),
+            address1=payload.get("address1") or payload.get("address_line1"),
+            address2=payload.get("address2") or payload.get("address_line2"),
+            postcode=payload.get("postcode") or payload.get("postal_code") or payload.get("zip"),
+            city=payload.get("city"),
+            code_insee=payload.get("code_insee"),
+            latitude=latitude,
+            longitude=longitude,
+            is_main_location=True,
+        )
+        return LocationTransformation(locations=[record])
+
+    def _transform_contact(self, payload: Dict[str, Any]) -> ContactTransformation:
+        object_id = payload.get("establishment_id") or payload.get("object_id")
+        channels: List[ContactChannelRecord] = []
+
+        for key, value in payload.items():
+            normalized_key = key.lower()
+            if isinstance(value, dict):
+                for nested_key, nested_value in value.items():
+                    channels.extend(self._create_contact_channels(object_id, nested_key, nested_value))
+            else:
+                channels.extend(self._create_contact_channels(object_id, normalized_key, value))
+
+        return ContactTransformation(channels=channels)
+
+    def _transform_amenities(self, payload: Dict[str, Any]) -> AmenityTransformation:
+        object_id = payload.get("establishment_id") or payload.get("object_id")
+        amenities = payload.get("amenities") or payload.get("equipment") or payload.get("services") or []
+        if isinstance(amenities, str):
+            amenities = re.split(r",|;|/", amenities)
+        links = []
+        for amenity in amenities:
+            if not amenity:
+                continue
+            code = _normalize(str(amenity))
+            links.append(
+                AmenityLinkRecord(object_id=object_id, amenity_code=code, raw_label=str(amenity).strip())
+            )
+        return AmenityTransformation(amenities=links)
+
+    def _transform_media(self, payload: Dict[str, Any]) -> MediaTransformation:
+        object_id = payload.get("establishment_id") or payload.get("object_id")
+        media_items = payload.get("media") or payload.get("photos") or payload.get("videos") or []
+        records: List[MediaRecord] = []
+        for item in media_items:
+            if isinstance(item, str):
+                media_type = self._infer_media_type(item)
+                records.append(
+                    MediaRecord(object_id=object_id, url=item, media_type_code=media_type)
+                )
+            elif isinstance(item, dict):
+                url = item.get("url") or item.get("link")
+                if not url:
+                    continue
+                media_type = item.get("media_type") or self._infer_media_type(url)
+                records.append(
+                    MediaRecord(
+                        object_id=object_id,
+                        url=url,
+                        media_type_code=media_type,
+                        title=item.get("title"),
+                        description=item.get("description"),
+                        credit=item.get("credit"),
+                        is_main=item.get("is_main"),
+                    )
+                )
+        return MediaTransformation(media=records)
+
+    def _guess_object_type(self, category: str) -> str:
+        if not category:
+            return "ORG"
+        lowered = category.lower()
+        for key, value in self.CATEGORY_TO_OBJECT_TYPE.items():
+            if key in lowered:
+                return value
+        return "ORG"
+
+    def _normalize_category(self, category: Optional[str]) -> Optional[str]:
+        if not category:
+            return None
+        return _normalize(category)
+
+    def _coerce_float(self, value: Any) -> Optional[float]:
+        if value in (None, "", []) or isinstance(value, dict):
+            return None
+        try:
+            return float(value)
+        except (ValueError, TypeError):  # pragma: no cover - defensive
+            return None
+
+    def _create_contact_channels(
+        self,
+        object_id: Optional[str],
+        key: str,
+        value: Any,
+    ) -> List[ContactChannelRecord]:
+        entries: List[ContactChannelRecord] = []
+        if value in (None, ""):
+            return entries
+
+        kind_code = self._infer_contact_kind(key)
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                if item:
+                    entries.append(ContactChannelRecord(object_id=object_id, value=str(item), kind_code=kind_code))
+            return entries
+
+        entries.append(ContactChannelRecord(object_id=object_id, value=str(value), kind_code=kind_code))
+        return entries
+
+    def _infer_contact_kind(self, key: str) -> str:
+        lowered = key.lower()
+        for keyword, code in self.CONTACT_KIND_DEFAULTS.items():
+            if keyword in lowered:
+                return code
+        return "other"
+
+    def _infer_media_type(self, value: str) -> str:
+        lowered = value.lower()
+        for keyword, code in self.MEDIA_TYPE_DEFAULTS.items():
+            if keyword in lowered:
+                return code
+        if any(lowered.endswith(ext) for ext in (".jpg", ".jpeg", ".png", ".gif", ".webp")):
+            return "image"
+        if any(lowered.endswith(ext) for ext in (".mp4", ".mov", ".avi", ".mkv")):
+            return "video"
+        return "image"
+
+
+class OpenAILLM(LLMClient):  # pragma: no cover - network dependency
+    """LLM client backed by OpenAI Responses API."""
+
+    def __init__(self, *, api_key: str, model: str, temperature: float = 0.0):
+        if AsyncOpenAI is None:
+            raise RuntimeError("The 'openai' package is required for the OpenAI provider.")
+        self._client = AsyncOpenAI(api_key=api_key)
+        self.model = model
+        self.temperature = temperature
+        self.name = "openai"
+
+    async def classify_fields(
+        self,
+        *,
+        payload: Dict[str, Any],
+        agent_descriptors: Sequence[AgentDescriptor],
+    ) -> FieldRoutingDecision:
+        system_prompt = (
+            "You classify establishment payload keys into specialised agents that prepare data for the DLL schema."
+            " Output a JSON object strictly matching the provided schema."
+        )
+        agents_description = ", ".join(
+            f"{descriptor.name}: {descriptor.description}" for descriptor in agent_descriptors
+        )
+        user_prompt = (
+            "Agents available: "
+            f"{agents_description}.\nPayload keys: "
+            f"{json.dumps(payload, ensure_ascii=False)}"
+        )
+        return await self._structured_response(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            response_model=FieldRoutingDecision,
+        )
+
+    async def transform_fragment(
+        self,
+        *,
+        agent_name: str,
+        payload: Dict[str, Any],
+        response_model: type[BaseModel],
+    ) -> BaseModel:
+        system_prompt = (
+            "You are an ingestion agent that converts noisy establishment information into the Supabase DLL structure."
+            " Follow the schema strictly and avoid fabricating values."
+        )
+        user_prompt = (
+            f"Agent: {agent_name}. Payload: {json.dumps(payload, ensure_ascii=False)}."
+            " Return only JSON that matches the expected schema."
+        )
+        return await self._structured_response(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            response_model=response_model,
+        )
+
+    async def _structured_response(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        response_model: type[BaseModel],
+    ) -> BaseModel:
+        schema = response_model.model_json_schema()
+        response = await self._client.responses.create(
+            model=self.model,
+            temperature=self.temperature,
+            input=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            response_format={
+                "type": "json_schema",
+                "json_schema": {"name": response_model.__name__, "schema": schema},
+            },
+        )
+
+        text = self._extract_text(response)
+        data = json.loads(text)
+        return response_model.model_validate(data)
+
+    def _extract_text(self, response: Any) -> str:
+        if hasattr(response, "output"):
+            for item in response.output:
+                content = getattr(item, "content", None)
+                if not content:
+                    continue
+                for block in content:
+                    text = getattr(block, "text", None)
+                    if text:
+                        return text
+        if hasattr(response, "output_text"):
+            return response.output_text  # type: ignore[attr-defined]
+        if hasattr(response, "choices"):
+            choice = response.choices[0]
+            message = getattr(choice, "message", None)
+            if message and getattr(message, "content", None):
+                return message.content  # type: ignore[return-value]
+        raise RuntimeError("Unable to extract response text from OpenAI result")
+
+
+def build_llm(
+    *,
+    provider: str,
+    api_key: Optional[str],
+    model: str,
+    temperature: float,
+) -> LLMClient:
+    provider = provider.lower()
+    if provider == "openai":  # pragma: no cover - requires network access
+        if not api_key:
+            raise RuntimeError("OpenAI provider selected but no API key was provided.")
+        return OpenAILLM(api_key=api_key, model=model, temperature=temperature)
+
+    if provider in {"auto", "default"}:
+        if api_key:
+            try:
+                return OpenAILLM(api_key=api_key, model=model, temperature=temperature)
+            except Exception:  # pragma: no cover - fallback if OpenAI not available
+                pass
+        return RuleBasedLLM()
+
+    if provider == "rule" or provider == "rule-based":
+        return RuleBasedLLM()
+
+    raise ValueError(f"Unknown AI provider '{provider}'")
+
+
+class FieldRouter:
+    """Semantic router that delegates routing to an LLM client."""
+
+    def __init__(self, llm: LLMClient):
+        self.llm = llm
+
+    async def route(
+        self,
+        *,
+        payload: Dict[str, Any],
+        agent_descriptors: Sequence[AgentDescriptor],
+    ) -> FieldRoutingDecision:
+        decision = await self.llm.classify_fields(payload=payload, agent_descriptors=agent_descriptors)
+
+        # Enrich sections for convenience
+        sections: Dict[str, Dict[str, Any]] = {descriptor.name: {} for descriptor in agent_descriptors}
+        leftovers = dict(decision.leftovers)
+
+        for assignment in decision.assignments:
+            value = payload.get(assignment.field_name)
+            if value is None:
+                continue
+            sections.setdefault(assignment.agent, {})[assignment.target_attribute or assignment.field_name] = value
+            leftovers.pop(assignment.field_name, None)
+
+        decision.sections = sections
+        decision.leftovers = leftovers
+        return decision
+
+
+__all__ = [
+    "LLMClient",
+    "RuleBasedLLM",
+    "OpenAILLM",
+    "build_llm",
+    "FieldRouter",
+]
+

--- a/migration-tool/migration_tool/config.py
+++ b/migration-tool/migration_tool/config.py
@@ -1,0 +1,36 @@
+"""Application configuration."""
+
+from functools import lru_cache
+from typing import Optional
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Environment driven configuration."""
+
+    supabase_url: Optional[str] = None
+    supabase_service_key: Optional[str] = None
+    webhook_url: Optional[str] = None
+    dashboard_retention: int = 200
+
+    ai_provider: str = "auto"
+    ai_model: str = "gpt-4o-mini"
+    ai_temperature: float = 0.0
+    openai_api_key: Optional[str] = None
+
+    model_config = SettingsConfigDict(
+        env_prefix="MIGRATION_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+    )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return a cached instance of :class:`Settings`."""
+
+    return Settings()
+
+
+__all__ = ["Settings", "get_settings"]

--- a/migration-tool/migration_tool/main.py
+++ b/migration-tool/migration_tool/main.py
@@ -1,0 +1,109 @@
+"""FastAPI application factory."""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Dict
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from .agents.amenities import AmenitiesAgent
+from .agents.contact import ContactAgent
+from .agents.coordinator import Coordinator
+from .agents.identity import IdentityAgent
+from .agents.location import LocationAgent
+from .agents.media import MediaAgent
+from .ai import FieldRouter, build_llm
+from .config import Settings, get_settings
+from .schemas import IngestionResponse, RawEstablishmentPayload
+from .supabase_client import SupabaseService
+from .telemetry import EventLog
+from .webhook import WebhookNotifier
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    if settings is None:
+        settings = get_settings()
+    telemetry = EventLog(retention=settings.dashboard_retention)
+    supabase = SupabaseService(settings.supabase_url, settings.supabase_service_key, telemetry)
+    webhook = WebhookNotifier(settings.webhook_url, telemetry)
+    llm = build_llm(
+        provider=settings.ai_provider,
+        api_key=settings.openai_api_key,
+        model=settings.ai_model,
+        temperature=settings.ai_temperature,
+    )
+    telemetry.record("ai.initialised", {"provider": getattr(llm, "name", "unknown")})
+    router = FieldRouter(llm)
+
+    coordinator = Coordinator(
+        identity_agent=IdentityAgent(supabase, telemetry, llm),
+        location_agent=LocationAgent(supabase, telemetry, llm),
+        contact_agent=ContactAgent(supabase, telemetry, llm),
+        amenities_agent=AmenitiesAgent(supabase, telemetry, llm),
+        media_agent=MediaAgent(supabase, telemetry, llm),
+        webhook=webhook,
+        telemetry=telemetry,
+        router=router,
+    )
+
+    app = FastAPI(title="Bertel Migration Tool", version="0.1.0")
+
+    templates_path = pathlib.Path(__file__).parent / "templates"
+    static_path = pathlib.Path(__file__).parent / "static"
+    templates = Jinja2Templates(directory=str(templates_path))
+
+    app.mount("/static", StaticFiles(directory=str(static_path)), name="static")
+
+    @app.on_event("startup")
+    async def _startup() -> None:  # pragma: no cover - FastAPI lifecycle
+        telemetry.record("app.startup", {})
+
+    @app.get("/", response_class=HTMLResponse)
+    async def dashboard(request: Request) -> HTMLResponse:
+        return templates.TemplateResponse(
+            "dashboard.html",
+            {
+                "request": request,
+            },
+        )
+
+    @app.get("/health")
+    async def health() -> Dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/events")
+    async def events() -> Dict[str, object]:
+        return {"events": telemetry.snapshot()}
+
+    @app.get("/agents")
+    async def agents() -> Dict[str, object]:
+        return {"agents": list(coordinator.descriptors())}
+
+    @app.post("/ingest", response_model=IngestionResponse)
+    async def ingest(payload: RawEstablishmentPayload) -> IngestionResponse:
+        fragments, leftovers = await coordinator.handle(payload)
+        response = IngestionResponse(
+            establishment_name=payload.establishment_name,
+            routed_fragments=fragments,
+            unresolved_fragments=leftovers,
+        )
+        telemetry.record(
+            "coordinator.responded",
+            response.model_dump(),
+        )
+        return response
+
+    return app
+
+
+def run() -> None:  # pragma: no cover - convenience script
+    import uvicorn
+
+    uvicorn.run("migration_tool.main:create_app", factory=True, reload=False)
+
+
+__all__ = ["create_app", "run"]

--- a/migration-tool/migration_tool/schemas.py
+++ b/migration-tool/migration_tool/schemas.py
@@ -1,0 +1,249 @@
+"""Pydantic models shared across the application."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class RawEstablishmentPayload(BaseModel):
+    """Envelope received from external systems."""
+
+    establishment_name: str = Field(..., alias="name")
+    establishment_category: Optional[str] = Field(None, alias="category")
+    establishment_subcategory: Optional[str] = Field(None, alias="subcategory")
+    legacy_ids: Optional[List[str]] = None
+    data: Dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {
+        "populate_by_name": True,
+        "extra": "allow",
+    }
+
+
+class RoutedFragment(BaseModel):
+    """Fragment routed to a specialised agent."""
+
+    agent: str
+    status: str
+    message: Optional[str] = None
+    payload: Dict[str, Any]
+
+
+class IngestionResponse(BaseModel):
+    """Response returned to the caller of the ingestion endpoint."""
+
+    establishment_name: str
+    routed_fragments: List[RoutedFragment]
+    unresolved_fragments: Dict[str, Any]
+
+
+class AgentDescriptor(BaseModel):
+    """Describe an agent for the dashboard."""
+
+    name: str
+    description: str
+    expected_fields: List[str]
+
+
+class AgentContext(BaseModel):
+    """Context shared with agents while processing a payload."""
+
+    coordinator_id: str
+    source_payload: Dict[str, Any]
+
+
+class FieldAssignment(BaseModel):
+    """Assignment produced by the semantic router."""
+
+    field_name: str
+    agent: str
+    target_attribute: Optional[str] = None
+    reasoning: Optional[str] = None
+
+
+class FieldRoutingDecision(BaseModel):
+    """Decision payload returned by the LLM router."""
+
+    assignments: List[FieldAssignment]
+    leftovers: Dict[str, Any] = Field(default_factory=dict)
+    sections: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+
+
+class IdentityRecord(BaseModel):
+    """Structured representation of the `object` table."""
+
+    object_id: Optional[str] = None
+    object_type: str
+    name: str
+    description: Optional[str] = None
+    status: str = "draft"
+    category_code: Optional[str] = None
+    subcategory_code: Optional[str] = None
+    legacy_ids: List[str] = Field(default_factory=list)
+    region_code: Optional[str] = None
+    source_extra: Dict[str, Any] = Field(default_factory=dict)
+
+    def to_supabase(self) -> Dict[str, Any]:
+        extra: Dict[str, Any] = {
+            "category": self.category_code,
+            "subcategory": self.subcategory_code,
+        }
+        if self.legacy_ids:
+            extra["legacy_ids"] = self.legacy_ids
+        if self.description:
+            extra.setdefault("descriptions", {})["default"] = self.description
+        if self.source_extra:
+            extra["source_payload"] = self.source_extra
+
+        payload = {
+            "id": self.object_id,
+            "object_type": self.object_type,
+            "name": self.name,
+            "status": self.status,
+        }
+        if self.region_code:
+            payload["region_code"] = self.region_code
+        cleaned_extra = {k: v for k, v in extra.items() if v not in (None, [], {}, "")}
+        if cleaned_extra:
+            payload["extra"] = cleaned_extra
+        return payload
+
+
+class LocationRecord(BaseModel):
+    """Structured representation of `object_location`."""
+
+    object_id: Optional[str]
+    address1: Optional[str] = None
+    address2: Optional[str] = None
+    postcode: Optional[str] = None
+    city: Optional[str] = None
+    code_insee: Optional[str] = None
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
+    is_main_location: bool = True
+
+    def to_supabase(self) -> Dict[str, Any]:
+        return {
+            "object_id": self.object_id,
+            "address1": self.address1,
+            "address2": self.address2,
+            "postcode": self.postcode,
+            "city": self.city,
+            "code_insee": self.code_insee,
+            "latitude": self.latitude,
+            "longitude": self.longitude,
+            "is_main_location": self.is_main_location,
+        }
+
+
+class LocationTransformation(BaseModel):
+    locations: List[LocationRecord]
+
+
+class ContactChannelRecord(BaseModel):
+    """Representation of `contact_channel`."""
+
+    object_id: Optional[str]
+    value: str
+    kind_code: str
+    role_code: Optional[str] = None
+    is_primary: Optional[bool] = None
+
+    def to_supabase(self, *, kind_id: Optional[str], role_id: Optional[str]) -> Dict[str, Any]:
+        payload = {
+            "object_id": self.object_id,
+            "value": self.value,
+            "is_primary": self.is_primary,
+        }
+        if kind_id:
+            payload["kind_id"] = kind_id
+        if role_id:
+            payload["role_id"] = role_id
+        metadata: Dict[str, Any] = {"kind_code": self.kind_code}
+        if self.role_code:
+            metadata["role_code"] = self.role_code
+        if metadata:
+            payload.setdefault("extra", {})
+            payload["extra"].update(metadata)
+        return payload
+
+
+class ContactTransformation(BaseModel):
+    channels: List[ContactChannelRecord]
+
+
+class AmenityLinkRecord(BaseModel):
+    """Representation of the `object_amenity` relation."""
+
+    object_id: Optional[str]
+    amenity_code: str
+    raw_label: Optional[str] = None
+
+    def to_supabase(self, *, amenity_id: Optional[str]) -> Dict[str, Any]:
+        payload = {
+            "object_id": self.object_id,
+            "amenity_id": amenity_id,
+        }
+        if self.raw_label:
+            payload["extra"] = {"raw_label": self.raw_label}
+        if not amenity_id:
+            payload.setdefault("extra", {})
+            payload["extra"]["amenity_code"] = self.amenity_code
+        return payload
+
+
+class AmenityTransformation(BaseModel):
+    amenities: List[AmenityLinkRecord]
+
+
+class MediaRecord(BaseModel):
+    """Representation of the `media` table."""
+
+    object_id: Optional[str]
+    url: str
+    media_type_code: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+    credit: Optional[str] = None
+    is_main: Optional[bool] = None
+
+    def to_supabase(self, *, media_type_id: Optional[str]) -> Dict[str, Any]:
+        payload = {
+            "object_id": self.object_id,
+            "url": self.url,
+            "media_type_id": media_type_id,
+            "title": self.title,
+            "description": self.description,
+            "credit": self.credit,
+            "is_main": self.is_main,
+        }
+        if not media_type_id:
+            payload.setdefault("extra", {})
+            payload["extra"]["media_type_code"] = self.media_type_code
+        return payload
+
+
+class MediaTransformation(BaseModel):
+    media: List[MediaRecord]
+
+
+__all__ = [
+    "RawEstablishmentPayload",
+    "RoutedFragment",
+    "IngestionResponse",
+    "AgentDescriptor",
+    "AgentContext",
+    "FieldAssignment",
+    "FieldRoutingDecision",
+    "IdentityRecord",
+    "LocationRecord",
+    "LocationTransformation",
+    "ContactChannelRecord",
+    "ContactTransformation",
+    "AmenityLinkRecord",
+    "AmenityTransformation",
+    "MediaRecord",
+    "MediaTransformation",
+]

--- a/migration-tool/migration_tool/static/dashboard.js
+++ b/migration-tool/migration_tool/static/dashboard.js
@@ -1,0 +1,54 @@
+async function fetchJSON(url) {
+  const response = await fetch(url, { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}`);
+  }
+  return response.json();
+}
+
+function renderAgents(container, agents) {
+  container.innerHTML = "";
+  agents.forEach((agent) => {
+    const wrapper = document.createElement("article");
+    wrapper.classList.add("agent");
+    wrapper.innerHTML = `
+      <h3>${agent.name}</h3>
+      <p>${agent.description}</p>
+      <div>${agent.expected_fields
+        .map((field) => `<span class="tag">${field}</span>`)
+        .join("")}</div>
+    `;
+    container.appendChild(wrapper);
+  });
+}
+
+function renderEvents(container, events) {
+  container.innerHTML = "";
+  events.forEach((event) => {
+    const wrapper = document.createElement("article");
+    wrapper.classList.add("event");
+    wrapper.innerHTML = `
+      <div class="timestamp">${new Date(event.timestamp).toLocaleString()}</div>
+      <h3>${event.type}</h3>
+      <pre>${JSON.stringify(event.payload, null, 2)}</pre>
+    `;
+    container.appendChild(wrapper);
+  });
+}
+
+async function refresh() {
+  try {
+    const [agents, events] = await Promise.all([
+      fetchJSON("/agents"),
+      fetchJSON("/events"),
+    ]);
+
+    renderAgents(document.getElementById("agents"), agents.agents);
+    renderEvents(document.getElementById("events"), events.events);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+refresh();
+setInterval(refresh, 4000);

--- a/migration-tool/migration_tool/static/styles.css
+++ b/migration-tool/migration_tool/static/styles.css
@@ -1,0 +1,81 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  padding: 0 2rem 2rem;
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+}
+
+header {
+  padding: 2rem 0 1rem;
+}
+
+h1 {
+  margin: 0;
+  font-size: 2.4rem;
+}
+
+main {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 25px 50px -12px rgba(30, 64, 175, 0.35);
+  backdrop-filter: blur(12px);
+}
+
+.panel h2 {
+  margin-top: 0;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+  color: #38bdf8;
+}
+
+.tag {
+  display: inline-block;
+  margin: 0.2rem;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.15);
+  color: #bfdbfe;
+  font-size: 0.75rem;
+}
+
+.event {
+  margin-bottom: 1.2rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px dashed rgba(148, 163, 184, 0.3);
+}
+
+.event h3 {
+  margin: 0 0 0.3rem;
+  font-size: 1rem;
+}
+
+.event pre {
+  margin: 0.3rem 0 0;
+  background: rgba(15, 23, 42, 0.65);
+  padding: 0.8rem;
+  border-radius: 12px;
+  overflow-x: auto;
+  font-size: 0.75rem;
+}
+
+.timestamp {
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.7);
+}

--- a/migration-tool/migration_tool/supabase_client.py
+++ b/migration-tool/migration_tool/supabase_client.py
@@ -1,0 +1,124 @@
+"""Supabase wrapper that degrades gracefully when credentials are missing."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+from supabase import Client, create_client
+
+from .telemetry import EventLog
+
+
+class SupabaseService:
+    """Facade encapsulating Supabase interactions."""
+
+    def __init__(self, url: Optional[str], key: Optional[str], telemetry: EventLog):
+        self.telemetry = telemetry
+        self._client: Optional[Client] = None
+        self._lookup_cache: Dict[Tuple[str, str, str], Optional[str]] = {}
+        if url and key:
+            self._client = create_client(url, key)
+            self.telemetry.record(
+                "supabase.connected",
+                {"url": url},
+            )
+        else:
+            self.telemetry.record(
+                "supabase.disabled",
+                {"reason": "missing credentials"},
+            )
+
+    @property
+    def client(self) -> Optional[Client]:
+        return self._client
+
+    async def upsert(
+        self,
+        table: str,
+        data: Union[Dict[str, Any], Sequence[Dict[str, Any]]],
+        *,
+        on_conflict: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Upsert data into a given table."""
+
+        if not self._client:
+            payload = {
+                "table": table,
+                "data": data,
+                "on_conflict": on_conflict,
+            }
+            self.telemetry.record("supabase.skipped", payload)
+            return {"status": "skipped", "reason": "no credentials", "payload": payload}
+
+        def _execute() -> Dict[str, Any]:
+            query = self._client.table(table).upsert(data)
+            if on_conflict:
+                query = query.on_conflict(on_conflict)
+            response = query.execute()
+            return getattr(response, "model_dump", lambda: response.__dict__)()
+
+        try:
+            result = await asyncio.to_thread(_execute)
+            self.telemetry.record(
+                "supabase.upsert",
+                {"table": table, "data": data, "on_conflict": on_conflict, "response": result},
+            )
+            return result
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self.telemetry.record(
+                "supabase.error",
+                {"table": table, "data": data, "error": str(exc)},
+            )
+            raise
+
+    async def lookup(self, table: str, *, code: str, code_field: str = "code") -> Optional[str]:
+        """Resolve a reference code to its primary key."""
+
+        cache_key = (table, code_field, code)
+        if cache_key in self._lookup_cache:
+            return self._lookup_cache[cache_key]
+
+        if not code:
+            self._lookup_cache[cache_key] = None
+            return None
+
+        if not self._client:
+            self._lookup_cache[cache_key] = None
+            self.telemetry.record(
+                "supabase.lookup.skipped",
+                {"table": table, "code": code, "reason": "no credentials"},
+            )
+            return None
+
+        def _execute() -> Optional[str]:
+            response = (
+                self._client.table(table)
+                .select("id")
+                .eq(code_field, code)
+                .limit(1)
+                .execute()
+            )
+            data: Optional[List[Dict[str, Any]]] = None
+            if hasattr(response, "data"):
+                data = response.data  # type: ignore[assignment]
+            elif isinstance(response, dict):
+                data = response.get("data")  # type: ignore[assignment]
+            else:
+                data = getattr(response, "__dict__", {}).get("data")
+            if data:
+                first = data[0]
+                if isinstance(first, dict):
+                    return str(first.get("id")) if first.get("id") else None
+            return None
+
+        identifier = await asyncio.to_thread(_execute)
+        self._lookup_cache[cache_key] = identifier
+        self.telemetry.record(
+            "supabase.lookup",
+            {"table": table, "code": code, "code_field": code_field, "resolved_id": identifier},
+        )
+        return identifier
+
+
+__all__ = ["SupabaseService"]

--- a/migration-tool/migration_tool/telemetry.py
+++ b/migration-tool/migration_tool/telemetry.py
@@ -1,0 +1,47 @@
+"""Simple in-memory telemetry store used by the dashboard."""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Deque, Dict, Iterable, List
+
+
+@dataclass(slots=True)
+class TelemetryEvent:
+    """Represent a single telemetry event."""
+
+    type: str
+    payload: Dict[str, Any]
+    timestamp: dt.datetime = field(default_factory=lambda: dt.datetime.now(dt.timezone.utc))
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "type": self.type,
+            "payload": self.payload,
+            "timestamp": self.timestamp.isoformat(),
+        }
+
+
+class EventLog:
+    """Fixed-size FIFO log of events."""
+
+    def __init__(self, retention: int = 200):
+        self._events: Deque[TelemetryEvent] = deque(maxlen=retention)
+
+    def record(self, event_type: str, payload: Dict[str, Any]) -> None:
+        self._events.appendleft(TelemetryEvent(type=event_type, payload=payload))
+
+    def bulk(self, events: Iterable[TelemetryEvent]) -> None:
+        for event in events:
+            self._events.appendleft(event)
+
+    def snapshot(self) -> List[Dict[str, Any]]:
+        return [event.as_dict() for event in self._events]
+
+    def clear(self) -> None:
+        self._events.clear()
+
+
+__all__ = ["EventLog", "TelemetryEvent"]

--- a/migration-tool/migration_tool/templates/dashboard.html
+++ b/migration-tool/migration_tool/templates/dashboard.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bertel Migration Dashboard</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Bertel Migration Dashboard</h1>
+      <p>Visualise incoming payloads, agent routing and unresolved fragments in real-time.</p>
+    </header>
+    <main>
+      <section class="panel" id="agents-panel">
+        <h2>Registered agents</h2>
+        <div id="agents"></div>
+      </section>
+      <section class="panel" id="events-panel">
+        <h2>Telemetry</h2>
+        <div id="events"></div>
+      </section>
+    </main>
+    <script src="/static/dashboard.js"></script>
+  </body>
+</html>

--- a/migration-tool/migration_tool/webhook.py
+++ b/migration-tool/migration_tool/webhook.py
@@ -1,0 +1,44 @@
+"""Webhook notifier used for unresolved fragments."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import httpx
+
+from .telemetry import EventLog
+
+
+class WebhookNotifier:
+    """Send asynchronous notifications to an external system."""
+
+    def __init__(self, url: Optional[str], telemetry: EventLog):
+        self.url = url
+        self.telemetry = telemetry
+        if not url:
+            self.telemetry.record(
+                "webhook.disabled",
+                {"reason": "missing url"},
+            )
+
+    async def notify(self, payload: Dict[str, Any]) -> None:
+        if not self.url:
+            self.telemetry.record("webhook.skipped", payload)
+            return
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(self.url, json=payload, timeout=10)
+                response.raise_for_status()
+                self.telemetry.record(
+                    "webhook.sent",
+                    {"payload": payload, "status_code": response.status_code},
+                )
+            except httpx.HTTPError as exc:  # pragma: no cover - network failure
+                self.telemetry.record(
+                    "webhook.error",
+                    {"payload": payload, "error": str(exc)},
+                )
+
+
+__all__ = ["WebhookNotifier"]

--- a/migration-tool/pyproject.toml
+++ b/migration-tool/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "bertel-migration-tool"
+version = "0.1.0"
+description = "Migration orchestrator and visualization tool for Bertel"
+authors = [{ name = "OTI du Sud" }]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.111.0",
+    "uvicorn[standard]>=0.30.1",
+    "pydantic>=2.7.1",
+    "pydantic-settings>=2.3.1",
+    "httpx>=0.27.0",
+    "supabase>=2.4.0",
+    "jinja2>=3.1.4"
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.2.0"]
+ai = ["openai>=1.30.0"]
+
+[project.scripts]
+bertel-migration-api = "migration_tool.main:run"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+

--- a/migration-tool/tests/conftest.py
+++ b/migration-tool/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))

--- a/migration-tool/tests/test_ai_routing.py
+++ b/migration-tool/tests/test_ai_routing.py
@@ -1,0 +1,59 @@
+import pytest
+
+from migration_tool.ai import FieldRouter, RuleBasedLLM
+from migration_tool.agents.identity import IdentityAgent
+from migration_tool.schemas import AgentContext, AgentDescriptor
+from migration_tool.supabase_client import SupabaseService
+from migration_tool.telemetry import EventLog
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_field_router_rule_based_assignment() -> None:
+    router = FieldRouter(RuleBasedLLM())
+    descriptors = [
+        AgentDescriptor(name="identity", description="identity", expected_fields=[]),
+        AgentDescriptor(name="location", description="location", expected_fields=[]),
+        AgentDescriptor(name="contact", description="contact", expected_fields=[]),
+    ]
+    payload = {
+        "establishment_name": "Hôtel des Tests",
+        "address_line1": "1 rue de la Paix",
+        "city": "Paris",
+        "phone": "+33 1 23 45 67 89",
+        "legacy_ids": ["LEG-123"],
+        "random_field": "keep me",
+    }
+
+    decision = await router.route(payload=payload, agent_descriptors=descriptors)
+
+    assert decision.sections["location"]["address1"] == "1 rue de la Paix"
+    assert decision.sections["contact"]["phone"] == "+33 1 23 45 67 89"
+    assert "random_field" in decision.leftovers
+
+
+@pytest.mark.anyio
+async def test_identity_agent_rule_based_transformation() -> None:
+    telemetry = EventLog(retention=10)
+    supabase = SupabaseService(url=None, key=None, telemetry=telemetry)
+    llm = RuleBasedLLM()
+    agent = IdentityAgent(supabase, telemetry, llm)
+
+    payload = {
+        "establishment_id": "TEST1234567890",
+        "establishment_name": "Base Test Hotel",
+        "category": "Hotel",
+        "legacy_ids": ["LEGACY-1"],
+        "description": "Bel établissement au centre-ville",
+    }
+    context = AgentContext(coordinator_id="coord", source_payload=payload)
+
+    result = await agent.handle(payload, context)
+
+    assert result["status"] == "ok"
+    assert result["table"] == "object"
+    assert result["response"]["status"] == "skipped"


### PR DESCRIPTION
## Summary
- add an AI abstraction layer with an OpenAI-backed option and a rule-based fallback to classify payload fields for the migration coordinator
- refactor the specialised agents to use semantic transformations aligned with the DLL schema and persist data via enriched Supabase helpers
- document the new configuration knobs, add AI-focused unit tests, and expose optional dependencies for language model integration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d504ebc14c83278e449f6c99fc54a2