### PR TITLE
Expand payload coercion for unstructured inputs

### DIFF
--- a/migration-tool/migration_tool/agents/amenities.py
+++ b/migration-tool/migration_tool/agents/amenities.py
@@ -38,7 +38,11 @@ class AmenitiesAgent(AIEnabledAgent):
         )
         responses = []
         for amenity in amenities:
-            amenity_id = await self.supabase.lookup("ref_amenity", code=amenity.amenity_code)
+            amenity_id = await self.supabase.ensure_amenity(
+                code=amenity.amenity_code,
+                name=amenity.amenity_name or amenity.raw_label,
+                family_code=amenity.amenity_family_code,
+            )
             data = amenity.to_supabase(amenity_id=amenity_id)
             responses.append(
                 await self.supabase.upsert(

--- a/migration-tool/migration_tool/agents/identity.py
+++ b/migration-tool/migration_tool/agents/identity.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+import re
+from typing import Any, Dict, Optional, Tuple
 
 from ..ai import LLMClient
 from ..schemas import AgentContext, IdentityRecord
@@ -35,17 +36,172 @@ class IdentityAgent(AIEnabledAgent):
             response_model=IdentityRecord,
         )
         data = record.to_supabase()
+
+        matched_existing = None
+        latitude = longitude = None
+        if not record.object_id:
+            latitude, longitude = self._extract_coordinates(context.source_payload)
+            matched_existing = await self.supabase.find_existing_object(
+                name=record.name,
+                latitude=latitude,
+                longitude=longitude,
+                category=record.category_code,
+                subcategory=record.subcategory_code,
+            )
+            if matched_existing and matched_existing.get("id"):
+                record.object_id = matched_existing["id"]
+                data["id"] = matched_existing["id"]
+                context.object_id = matched_existing["id"]
+                context.duplicate_of = matched_existing["id"]
+
         self.telemetry.record(
             "agent.identity.transform",
             {"context": context.model_dump(), "payload": payload, "record": record.model_dump(), "data": data},
         )
+
         response = await self.supabase.upsert("object", data, on_conflict="id")
+        object_id = record.object_id or self._extract_object_id(response)
+        if object_id:
+            record.object_id = object_id
+            context.object_id = object_id
+
+        organization_id = context.source_organization_id or self._extract_organization_id(
+            context.source_payload
+        )
+        external_id_results = []
+        if object_id and organization_id and record.legacy_ids:
+            external_id_results = await self.supabase.record_external_ids(
+                object_id=object_id,
+                organization_id=organization_id,
+                external_ids=record.legacy_ids,
+            )
+
+        if matched_existing:
+            self.telemetry.record(
+                "agent.identity.dedup",
+                {
+                    "context": context.model_dump(),
+                    "matched": matched_existing,
+                    "latitude": latitude,
+                    "longitude": longitude,
+                },
+            )
+
         return {
             "status": "ok",
             "operation": "upsert",
             "table": "object",
             "response": response,
+            "object_id": object_id,
+            "duplicate_of": matched_existing.get("id") if matched_existing else None,
+            "external_ids": external_id_results,
         }
+
+    def _extract_object_id(self, response: Dict[str, Any]) -> Optional[str]:
+        if not isinstance(response, dict):
+            return None
+        data = response.get("data")
+        if isinstance(data, list) and data:
+            first = data[0]
+            if isinstance(first, dict) and first.get("id"):
+                return str(first["id"])
+        if response.get("id"):
+            return str(response["id"])
+        return None
+
+    def _extract_coordinates(self, payload: Dict[str, Any]) -> Tuple[Optional[float], Optional[float]]:
+        latitude: Optional[float] = None
+        longitude: Optional[float] = None
+
+        if not payload:
+            return None, None
+
+        def coerce(value: Any) -> Optional[float]:
+            if value is None:
+                return None
+            try:
+                text = str(value).strip().replace(",", ".")
+                if not text:
+                    return None
+                return float(text)
+            except (TypeError, ValueError):
+                return None
+
+        def parse_string(key: str, value: str) -> None:
+            nonlocal latitude, longitude
+            key_lower = key.lower()
+            if not any(token in key_lower for token in ("lat", "lon", "lng", "coord", "gps")):
+                return
+            matches = re.findall(r"-?\d+(?:[\.,]\d+)?", value)
+            if len(matches) >= 2:
+                if latitude is None:
+                    latitude = coerce(matches[0])
+                if longitude is None:
+                    longitude = coerce(matches[1])
+
+        def visit(obj: Any, key: str = "") -> None:
+            nonlocal latitude, longitude
+            if latitude is not None and longitude is not None:
+                return
+            if isinstance(obj, dict):
+                for child_key, child_value in obj.items():
+                    visit(child_value, child_key)
+            elif isinstance(obj, (list, tuple)):
+                for item in obj:
+                    visit(item, key)
+            elif isinstance(obj, str):
+                parse_string(key, obj)
+                if latitude is None or longitude is None:
+                    if "," in obj or ";" in obj:
+                        parts = re.split(r"[,;]", obj)
+                        if len(parts) >= 2:
+                            lat_candidate = coerce(parts[0])
+                            lon_candidate = coerce(parts[1])
+                            latitude = latitude or lat_candidate
+                            longitude = longitude or lon_candidate
+            else:
+                key_lower = key.lower()
+                value = coerce(obj)
+                if value is not None:
+                    if "lat" in key_lower and latitude is None:
+                        latitude = value
+                    elif any(token in key_lower for token in ("lon", "lng", "long")) and longitude is None:
+                        longitude = value
+
+        visit(payload)
+        return latitude, longitude
+
+    def _extract_organization_id(self, payload: Dict[str, Any]) -> Optional[str]:
+        candidate_keys = (
+            "organization_id",
+            "organization_object_id",
+            "source_organization_id",
+            "dataprovidingorg",
+            "provider_id",
+            "provider_organization_id",
+            "owner_id",
+        )
+
+        def visit(obj: Any) -> Optional[str]:
+            if isinstance(obj, dict):
+                for key, value in obj.items():
+                    key_lower = key.lower()
+                    if any(candidate in key_lower for candidate in candidate_keys):
+                        if isinstance(value, (str, int)):
+                            text = str(value).strip()
+                            if text:
+                                return text
+                    result = visit(value)
+                    if result:
+                        return result
+            elif isinstance(obj, (list, tuple)):
+                for item in obj:
+                    result = visit(item)
+                    if result:
+                        return result
+            return None
+
+        return visit(payload or {})
 
 
 __all__ = ["IdentityAgent"]

--- a/migration-tool/migration_tool/schemas.py
+++ b/migration-tool/migration_tool/schemas.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+import json
+import re
+import xml.etree.ElementTree as ET
+from typing import Any, Dict, List, Optional, Sequence
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class RawEstablishmentPayload(BaseModel):
@@ -13,6 +16,7 @@ class RawEstablishmentPayload(BaseModel):
     establishment_name: str = Field(..., alias="name")
     establishment_category: Optional[str] = Field(None, alias="category")
     establishment_subcategory: Optional[str] = Field(None, alias="subcategory")
+    source_organization_id: Optional[str] = Field(None, alias="dataProvidingOrg")
     legacy_ids: Optional[List[str]] = None
     data: Dict[str, Any] = Field(default_factory=dict)
 
@@ -20,6 +24,334 @@ class RawEstablishmentPayload(BaseModel):
         "populate_by_name": True,
         "extra": "allow",
     }
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_payload(cls, value: Any) -> Any:
+        """Normalise legacy list-based payloads into a dictionary."""
+
+        raw_text: Optional[str] = None
+
+        if isinstance(value, (bytes, bytearray)):
+            try:
+                value = value.decode("utf-8")
+            except UnicodeDecodeError:
+                value = value.decode("latin-1", errors="ignore")
+
+        if isinstance(value, str):
+            raw_text = value
+            parsed = cls._parse_string_payload(value)
+            value = parsed
+
+        if isinstance(value, list):
+            pass
+        elif not isinstance(value, dict):
+            value = {"data": {}}
+
+        def _as_list(obj: Any) -> List[Dict[str, Any]]:
+            if isinstance(obj, list):
+                return [item for item in obj if isinstance(item, dict)]
+            if isinstance(obj, dict):
+                return [obj]
+            return []
+
+        def _split_values(raw: Optional[str]) -> List[str]:
+            if not raw:
+                return []
+            if isinstance(raw, str):
+                parts = [item.strip() for item in re.split(r"[,;/]", raw) if item.strip()]
+                return parts
+            if isinstance(raw, (list, tuple)):
+                return [str(item).strip() for item in raw if str(item).strip()]
+            return []
+
+        def _coerce_float(raw_value: Any) -> Optional[float]:
+            if raw_value is None:
+                return None
+            try:
+                text = str(raw_value).strip().replace(",", ".")
+                if not text:
+                    return None
+                return float(text)
+            except (TypeError, ValueError):
+                return None
+
+        def _parse_coordinates(raw: Optional[str]) -> tuple[Optional[float], Optional[float]]:
+            if not raw:
+                return None, None
+            try:
+                parts = re.findall(r"-?\d+(?:[\.,]\d+)?", str(raw))
+                if len(parts) >= 2:
+                    lat = float(parts[0].replace(",", "."))
+                    lon = float(parts[1].replace(",", "."))
+                    return lat, lon
+            except (TypeError, ValueError):
+                return None, None
+            return None, None
+
+        raw_blocks: List[Dict[str, Any]] = []
+
+        if isinstance(value, list):
+            if not value:
+                return {}
+            raw_batch = value
+            primary = value[0]
+            extras = value[1:]
+            if isinstance(primary, dict):
+                value = dict(primary)
+                value.setdefault("data", {})
+                if not isinstance(value["data"], dict):
+                    value["data"] = {}
+                value["data"].setdefault("raw_batch", raw_batch)
+                raw_blocks = _as_list(raw_batch)
+            else:
+                value = {"data": {}}
+            if extras:
+                value.setdefault("data", {})
+                value["data"]["additional_batches"] = extras
+
+        if not isinstance(value, dict):
+            return value
+
+        if "data" in value and not isinstance(value["data"], dict):
+            value["data"] = {}
+
+        if raw_text:
+            value.setdefault("data", {})
+            if isinstance(value["data"], dict) and "raw_payload" not in value["data"]:
+                value["data"]["raw_payload"] = raw_text
+
+        payload_data = value.get("data")
+        queue: List[Dict[str, Any]] = list(raw_blocks) if raw_blocks else _as_list(payload_data)
+        if isinstance(value, dict):
+            top_level = {
+                key: entry
+                for key, entry in value.items()
+                if key not in {"data", "legacy_ids"}
+            }
+            if top_level:
+                queue.insert(0, top_level)
+        main_record: Dict[str, Any] = {}
+        additional_sections: Dict[str, Any] = {}
+
+        while queue:
+            block = queue.pop(0)
+            if not isinstance(block, dict):
+                continue
+            if "data" in block and isinstance(block["data"], list):
+                additional_sections.setdefault("raw_blocks", []).append(block["data"])
+                queue.extend(_as_list(block["data"]))
+                continue
+            if "Presta ID" in block:
+                additional_sections.setdefault("providers", []).append(block)
+                continue
+            if "Horaires_id" in block:
+                additional_sections.setdefault("schedule", []).append(block)
+                continue
+            if "id_multimedia" in block:
+                media_item = {
+                    "url": block.get("lien") or block.get("url"),
+                    "description": block.get("description"),
+                    "title": block.get("description"),
+                    "is_main": block.get("principale"),
+                    "media_type": (block.get("type") or "").split("/")[0],
+                    "metadata": block,
+                }
+                additional_sections.setdefault("media", []).append(media_item)
+                continue
+            if "Id_Tarifs" in block:
+                additional_sections.setdefault("tariffs", []).append(block)
+                continue
+            if "Type_R_S" in block:
+                social_item = {
+                    "network": block.get("Type_R_S"),
+                    "url": block.get("URL"),
+                }
+                additional_sections.setdefault("socials", []).append(social_item)
+                continue
+            main_record.update(block)
+
+        value.setdefault("legacy_ids", [])
+        legacy_candidates = []
+        for key in ("id OTI", "ID_IRT", "Num taxe de séjour", "temp_ID_Presta"):
+            candidate = main_record.get(key)
+            if candidate:
+                legacy_candidates.append(str(candidate))
+        existing_legacy = cls._ensure_sequence(value.get("legacy_ids"))
+        value["legacy_ids"] = list(dict.fromkeys([*existing_legacy, *legacy_candidates]))
+
+        if main_record:
+            value["name"] = value.get("name") or main_record.get("Nom_OTI") or main_record.get("Nom") or main_record.get("Nom établissement")
+            value["category"] = value.get("category") or main_record.get("Nom catégorie") or main_record.get("Groupe catégorie")
+            value["subcategory"] = value.get("subcategory") or main_record.get("Nom sous catégorie")
+
+            address_parts = [str(main_record.get("Numéro")) if main_record.get("Numéro") else None, main_record.get("rue")]
+            address_line1 = " ".join(part for part in address_parts if part).strip() or None
+            latitude, longitude = _parse_coordinates(main_record.get("Coordonnées GPS"))
+            latitude = latitude if latitude is not None else _coerce_float(main_record.get("latitude"))
+            longitude = longitude if longitude is not None else _coerce_float(main_record.get("longitude"))
+
+            description = main_record.get("Descriptif OTI") or main_record.get("Descriptif du plan d'accès")
+            summary = main_record.get("Accroche OTI")
+
+            structured = {
+                "address_line1": address_line1,
+                "address_line2": main_record.get("Lieux-dits"),
+                "postcode": str(main_record.get("Code Postal")) if main_record.get("Code Postal") else None,
+                "city": main_record.get("ville"),
+                "latitude": latitude,
+                "longitude": longitude,
+                "description": description,
+                "summary": summary,
+                "status": main_record.get("Status"),
+                "amenities": _split_values(main_record.get("Prestations sur place")),
+                "nearby_services": _split_values(main_record.get("Prestations à proximité")),
+                "payment_methods": _split_values(main_record.get("Mode de paiement")),
+                "languages": _split_values(main_record.get("Langues")),
+                "email": main_record.get("E-Mail"),
+                "phone": [
+                    phone
+                    for phone in [
+                        main_record.get("Contact principale"),
+                        main_record.get("Autre téléphone"),
+                    ]
+                    if phone
+                ],
+                "website": main_record.get("Web"),
+                "raw_main_record": main_record,
+                "main_media": main_record.get("Main_Img"),
+                "accessibility": main_record.get("Handicap"),
+                "pets_allowed": main_record.get("Animaux"),
+                "source_status": main_record.get("SIT"),
+            }
+
+            value.setdefault("data", {})
+            for key, entry in structured.items():
+                if entry not in (None, [], ""):
+                    value["data"][key] = entry
+
+        if additional_sections:
+            value.setdefault("data", {})
+            for key, entry in additional_sections.items():
+                value["data"][key] = entry
+
+        return value
+
+    @staticmethod
+    def _parse_string_payload(raw: str) -> Any:
+        stripped = raw.strip()
+        if not stripped:
+            return {"data": {"raw_payload": raw}}
+
+        # JSON payloads
+        try:
+            parsed = json.loads(stripped)
+            return parsed
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        # XML payloads
+        try:
+            root = ET.fromstring(stripped)
+        except ET.ParseError:
+            root = None
+
+        if root is not None:
+            parsed_xml = RawEstablishmentPayload._collapse_single_key(
+                RawEstablishmentPayload._etree_to_object(root)
+            )
+            if isinstance(parsed_xml, dict):
+                parsed_xml.setdefault("data", {})
+                if isinstance(parsed_xml["data"], dict):
+                    parsed_xml["data"].setdefault("raw_xml_tag", root.tag)
+                return parsed_xml
+            return {"data": {"raw_payload": raw, "raw_xml_tag": root.tag}}
+
+        # Key-value style text payloads
+        kv_pairs: Dict[str, Any] = {}
+        for line in re.split(r"[\r\n;]+", stripped):
+            if not line.strip():
+                continue
+            if ":" in line:
+                key, value = line.split(":", 1)
+            elif "=" in line:
+                key, value = line.split("=", 1)
+            else:
+                continue
+            key = key.strip()
+            value = value.strip()
+            if key:
+                kv_pairs[key] = value
+
+        if kv_pairs:
+            return kv_pairs
+
+        return {"data": {"raw_payload": raw}}
+
+    @staticmethod
+    def _etree_to_object(element: ET.Element) -> Dict[str, Any]:
+        def convert(node: ET.Element) -> Any:
+            children = list(node)
+            attribs = {f"@{k}": v for k, v in node.attrib.items()}
+            text = (node.text or "").strip()
+
+            if not children:
+                if attribs and text:
+                    attribs["#text"] = text
+                    return attribs
+                if attribs:
+                    return attribs
+                return text or None
+
+            result: Dict[str, Any] = dict(attribs)
+            for child in children:
+                child_value = convert(child)
+                if child.tag in result:
+                    existing = result[child.tag]
+                    if not isinstance(existing, list):
+                        result[child.tag] = [existing]
+                    result[child.tag].append(child_value)
+                else:
+                    result[child.tag] = child_value
+            if text:
+                result.setdefault("#text", text)
+            return result
+
+        return {element.tag: convert(element)}
+
+    @staticmethod
+    def _collapse_single_key(value: Any) -> Any:
+        if isinstance(value, dict) and len(value) == 1:
+            inner_value = next(iter(value.values()))
+            if isinstance(inner_value, dict):
+                return RawEstablishmentPayload._collapse_single_key(inner_value)
+            return inner_value
+        return value
+
+    @staticmethod
+    def _ensure_sequence(value: Any) -> List[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        if isinstance(value, (list, tuple, set)):
+            return [str(item) for item in value if str(item).strip()]
+        if isinstance(value, dict):
+            collected: List[str] = []
+            for item in value.values():
+                if isinstance(item, (list, tuple, set)):
+                    collected.extend(str(child) for child in item if str(child).strip())
+                elif isinstance(item, dict):
+                    collected.extend(RawEstablishmentPayload._ensure_sequence(item))
+                else:
+                    text = str(item).strip()
+                    if text:
+                        collected.append(text)
+            return collected
+        if isinstance(value, Sequence):
+            return [str(item) for item in value if str(item).strip()]
+        text = str(value).strip()
+        return [text] if text else []
 
 
 class RoutedFragment(BaseModel):
@@ -52,6 +384,9 @@ class AgentContext(BaseModel):
 
     coordinator_id: str
     source_payload: Dict[str, Any]
+    object_id: Optional[str] = None
+    duplicate_of: Optional[str] = None
+    source_organization_id: Optional[str] = None
 
 
 class FieldAssignment(BaseModel):
@@ -98,11 +433,12 @@ class IdentityRecord(BaseModel):
             extra["source_payload"] = self.source_extra
 
         payload = {
-            "id": self.object_id,
             "object_type": self.object_type,
             "name": self.name,
             "status": self.status,
         }
+        if self.object_id:
+            payload["id"] = self.object_id
         if self.region_code:
             payload["region_code"] = self.region_code
         cleaned_extra = {k: v for k, v in extra.items() if v not in (None, [], {}, "")}
@@ -179,6 +515,8 @@ class AmenityLinkRecord(BaseModel):
 
     object_id: Optional[str]
     amenity_code: str
+    amenity_name: Optional[str] = None
+    amenity_family_code: Optional[str] = None
     raw_label: Optional[str] = None
 
     def to_supabase(self, *, amenity_id: Optional[str]) -> Dict[str, Any]:
@@ -191,6 +529,8 @@ class AmenityLinkRecord(BaseModel):
         if not amenity_id:
             payload.setdefault("extra", {})
             payload["extra"]["amenity_code"] = self.amenity_code
+            if self.amenity_name:
+                payload["extra"]["amenity_name"] = self.amenity_name
         return payload
 
 

--- a/migration-tool/migration_tool/supabase_client.py
+++ b/migration-tool/migration_tool/supabase_client.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+import re
+import unicodedata
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 from supabase import Client, create_client
 
@@ -75,11 +77,12 @@ class SupabaseService:
     async def lookup(self, table: str, *, code: str, code_field: str = "code") -> Optional[str]:
         """Resolve a reference code to its primary key."""
 
-        cache_key = (table, code_field, code)
+        normalized_code = self.normalize_code(code) if code_field == "code" else str(code)
+        cache_key = (table, code_field, normalized_code)
         if cache_key in self._lookup_cache:
             return self._lookup_cache[cache_key]
 
-        if not code:
+        if not normalized_code:
             self._lookup_cache[cache_key] = None
             return None
 
@@ -95,7 +98,7 @@ class SupabaseService:
             response = (
                 self._client.table(table)
                 .select("id")
-                .eq(code_field, code)
+                .eq(code_field, normalized_code)
                 .limit(1)
                 .execute()
             )
@@ -116,9 +119,279 @@ class SupabaseService:
         self._lookup_cache[cache_key] = identifier
         self.telemetry.record(
             "supabase.lookup",
-            {"table": table, "code": code, "code_field": code_field, "resolved_id": identifier},
+            {
+                "table": table,
+                "code": normalized_code,
+                "code_field": code_field,
+                "resolved_id": identifier,
+            },
         )
         return identifier
+
+    def normalize_code(self, code: str) -> str:
+        """Normalise a label/code into the DLL slug format."""
+
+        text = unicodedata.normalize("NFKD", str(code))
+        text = "".join(ch for ch in text if not unicodedata.combining(ch))
+        text = re.sub(r"[^a-z0-9]+", "_", text.lower())
+        return text.strip("_")
+
+    async def ensure_code(
+        self,
+        *,
+        domain: str,
+        code: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Ensure a ref_code entry exists and return its identifier."""
+
+        normalized_code = self.normalize_code(code)
+        existing = await self.lookup(f"ref_code_{domain}", code=normalized_code)
+        if existing:
+            return existing
+
+        payload = {
+            "domain": domain,
+            "code": normalized_code,
+            "name": name or code.title(),
+        }
+        if description:
+            payload["description"] = description
+        if metadata:
+            payload["metadata"] = metadata
+
+        await self.upsert("ref_code", payload, on_conflict="domain,code")
+        cache_key = (f"ref_code_{domain}", "code", normalized_code)
+        self._lookup_cache.pop(cache_key, None)
+        return await self.lookup(f"ref_code_{domain}", code=normalized_code)
+
+    async def ensure_amenity(
+        self,
+        *,
+        code: str,
+        name: Optional[str],
+        family_code: Optional[str] = None,
+    ) -> Optional[str]:
+        """Ensure an amenity exists in the reference table."""
+
+        normalized_code = self.normalize_code(code)
+        existing = await self.lookup("ref_amenity", code=normalized_code)
+        if existing:
+            return existing
+
+        family_slug = self.normalize_code(family_code) if family_code else "services"
+        family_id = await self.ensure_code(domain="amenity_family", code=family_slug, name=family_code or "Services")
+
+        payload = {
+            "code": normalized_code,
+            "name": name or normalized_code.replace("_", " ").title(),
+            "family_id": family_id,
+            "scope": "object",
+        }
+
+        response = await self.upsert("ref_amenity", payload, on_conflict="code")
+        data = response.get("data") if isinstance(response, dict) else None
+        if isinstance(data, list) and data:
+            identifier = data[0].get("id")
+            return str(identifier) if identifier else await self.lookup("ref_amenity", code=normalized_code)
+        cache_key = ("ref_amenity", "code", normalized_code)
+        self._lookup_cache.pop(cache_key, None)
+        return await self.lookup("ref_amenity", code=normalized_code)
+
+    async def find_existing_object(
+        self,
+        *,
+        name: Optional[str],
+        latitude: Optional[float],
+        longitude: Optional[float],
+        category: Optional[str],
+        subcategory: Optional[str],
+    ) -> Optional[Dict[str, Any]]:
+        """Find an existing object matching the provided identity features."""
+
+        if not self._client:
+            self.telemetry.record(
+                "supabase.dedup.skipped",
+                {
+                    "reason": "no credentials",
+                    "name": name,
+                    "latitude": latitude,
+                    "longitude": longitude,
+                    "category": category,
+                    "subcategory": subcategory,
+                },
+            )
+            return None
+
+        def _extract_data(response: Any) -> List[Dict[str, Any]]:
+            if hasattr(response, "data"):
+                return getattr(response, "data") or []  # type: ignore[return-value]
+            if isinstance(response, dict):
+                data = response.get("data")
+                if isinstance(data, list):
+                    return data
+            return getattr(response, "__dict__", {}).get("data", []) or []
+
+        def _matches_category(candidate: Dict[str, Any]) -> bool:
+            extra = candidate.get("extra") or {}
+            candidate_category = (extra.get("category") or "").lower() if isinstance(extra, dict) else None
+            candidate_subcategory = (extra.get("subcategory") or "").lower() if isinstance(extra, dict) else None
+
+            def _normalize(value: Optional[str]) -> Optional[str]:
+                return value.lower() if isinstance(value, str) else None
+
+            category_match = not category or not candidate_category or _normalize(category) == candidate_category
+            subcategory_match = not subcategory or not candidate_subcategory or _normalize(subcategory) == candidate_subcategory
+            return category_match and subcategory_match
+
+        def _fetch_objects(object_ids: Iterable[str]) -> List[Dict[str, Any]]:
+            unique_ids: List[str] = [oid for oid in dict.fromkeys(object_ids) if oid]
+            if not unique_ids:
+                return []
+            response = (
+                self._client.table("object")
+                .select("id,name,object_type,extra")
+                .in_("id", unique_ids)
+                .execute()
+            )
+            return _extract_data(response)
+
+        def _execute() -> Optional[Dict[str, Any]]:
+            coordinate_candidates: List[Dict[str, Any]] = []
+            if latitude is not None and longitude is not None:
+                location_response = (
+                    self._client.table("object_location")
+                    .select("object_id,latitude,longitude")
+                    .eq("latitude", latitude)
+                    .eq("longitude", longitude)
+                    .execute()
+                )
+                coordinate_ids = [row.get("object_id") for row in _extract_data(location_response) if isinstance(row, dict)]
+                coordinate_candidates = _fetch_objects(oid for oid in coordinate_ids if oid)
+
+            for candidate in coordinate_candidates:
+                if not isinstance(candidate, dict):
+                    continue
+                if _matches_category(candidate):
+                    candidate["match_reason"] = "coordinates"
+                    return candidate
+
+            name_candidates: List[Dict[str, Any]] = []
+            if name:
+                query = self._client.table("object").select("id,name,object_type,extra")
+                ilike_method = getattr(query, "ilike", None)
+                if callable(ilike_method):
+                    query = ilike_method("name", name)
+                else:
+                    query = query.eq("name", name)
+                name_response = query.execute()
+                name_candidates = _extract_data(name_response)
+
+            for candidate in name_candidates:
+                if not isinstance(candidate, dict):
+                    continue
+                if _matches_category(candidate):
+                    candidate["match_reason"] = "name"
+                    return candidate
+            return None
+
+        try:
+            match = await asyncio.to_thread(_execute)
+            self.telemetry.record(
+                "supabase.dedup.lookup",
+                {
+                    "name": name,
+                    "latitude": latitude,
+                    "longitude": longitude,
+                    "category": category,
+                    "subcategory": subcategory,
+                    "match": match,
+                },
+            )
+            return match
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self.telemetry.record(
+                "supabase.dedup.error",
+                {
+                    "name": name,
+                    "latitude": latitude,
+                    "longitude": longitude,
+                    "category": category,
+                    "subcategory": subcategory,
+                    "error": str(exc),
+                },
+            )
+            return None
+
+    async def record_external_ids(
+        self,
+        *,
+        object_id: str,
+        organization_id: str,
+        external_ids: Sequence[str],
+    ) -> List[Dict[str, Any]]:
+        """Persist external identifiers linked to an object."""
+
+        normalized_ids = [str(identifier) for identifier in dict.fromkeys(external_ids) if identifier]
+        if not normalized_ids or not object_id or not organization_id:
+            return []
+
+        payload = [
+            {
+                "object_id": object_id,
+                "organization_object_id": organization_id,
+                "external_id": identifier,
+            }
+            for identifier in normalized_ids
+        ]
+
+        if not self._client:
+            self.telemetry.record(
+                "supabase.external_ids.skipped",
+                {
+                    "reason": "no credentials",
+                    "object_id": object_id,
+                    "organization_id": organization_id,
+                    "external_ids": normalized_ids,
+                },
+            )
+            return []
+
+        def _execute() -> Dict[str, Any]:
+            response = (
+                self._client.table("object_external_id")
+                .upsert(payload)
+                .on_conflict("organization_object_id,external_id")
+                .execute()
+            )
+            return getattr(response, "model_dump", lambda: response.__dict__)()
+
+        try:
+            result = await asyncio.to_thread(_execute)
+            self.telemetry.record(
+                "supabase.external_ids.upsert",
+                {
+                    "object_id": object_id,
+                    "organization_id": organization_id,
+                    "external_ids": normalized_ids,
+                    "response": result,
+                },
+            )
+            data = result.get("data") if isinstance(result, dict) else None
+            return data if isinstance(data, list) else []
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self.telemetry.record(
+                "supabase.external_ids.error",
+                {
+                    "object_id": object_id,
+                    "organization_id": organization_id,
+                    "external_ids": normalized_ids,
+                    "error": str(exc),
+                },
+            )
+            return []
 
 
 __all__ = ["SupabaseService"]

--- a/migration-tool/tests/test_identity_agent.py
+++ b/migration-tool/tests/test_identity_agent.py
@@ -1,0 +1,123 @@
+import pytest
+
+from migration_tool.agents.identity import IdentityAgent
+from migration_tool.schemas import AgentContext, IdentityRecord
+from migration_tool.telemetry import EventLog
+from migration_tool.ai import LLMClient
+
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+
+class DummyLLM(LLMClient):
+    name = "dummy"
+
+    async def classify_fields(self, *, payload, agent_descriptors):  # pragma: no cover - unused in tests
+        raise NotImplementedError
+
+    async def transform_fragment(self, *, agent_name, payload, response_model):
+        return IdentityRecord(
+            object_id=payload.get("establishment_id"),
+            object_type="HOT",
+            name=payload.get("establishment_name", "Unknown"),
+            description=payload.get("description"),
+            category_code="res",
+            subcategory_code="bar",
+            legacy_ids=payload.get("legacy_ids", []),
+            source_extra={k: v for k, v in payload.items() if k not in {"establishment_name", "legacy_ids"}},
+        )
+
+
+class StubSupabase:
+    def __init__(self) -> None:
+        self.upserts = []
+        self.find_kwargs = None
+        self.find_result = None
+        self.external_calls = []
+        self.generated_id = "GEN-001"
+
+    async def upsert(self, table, data, on_conflict=None):
+        self.upserts.append((table, data, on_conflict))
+        identifier = data.get("id") or self.generated_id
+        return {"data": [{"id": identifier}]}
+
+    async def find_existing_object(self, **kwargs):
+        self.find_kwargs = kwargs
+        return self.find_result
+
+    async def record_external_ids(self, *, object_id, organization_id, external_ids):
+        call = {
+            "object_id": object_id,
+            "organization_id": organization_id,
+            "external_ids": list(external_ids),
+        }
+        self.external_calls.append(call)
+        return [{"object_id": object_id, "external_id": ext} for ext in external_ids]
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def test_identity_agent_reuses_existing_object():
+    supabase = StubSupabase()
+    supabase.find_result = {"id": "OBJ-123", "match_reason": "coordinates"}
+    agent = IdentityAgent(supabase=supabase, telemetry=EventLog(), llm=DummyLLM())
+
+    payload = {
+        "establishment_name": "Test Establishment",
+        "legacy_ids": ["LEG-001"],
+        "description": "Sample",
+    }
+    context = AgentContext(
+        coordinator_id="coord",
+        source_payload={
+            "latitude": 12.34,
+            "longitude": 56.78,
+            "provider_id": "ORG-777",
+        },
+    )
+
+    result = await agent.handle(payload, context)
+
+    assert result["object_id"] == "OBJ-123"
+    assert result["duplicate_of"] == "OBJ-123"
+    assert context.object_id == "OBJ-123"
+    assert context.duplicate_of == "OBJ-123"
+    assert supabase.find_kwargs == {
+        "name": "Test Establishment",
+        "latitude": 12.34,
+        "longitude": 56.78,
+        "category": "res",
+        "subcategory": "bar",
+    }
+    assert supabase.upserts[0][1]["id"] == "OBJ-123"
+    assert supabase.external_calls == [
+        {"object_id": "OBJ-123", "organization_id": "ORG-777", "external_ids": ["LEG-001"]}
+    ]
+
+
+async def test_identity_agent_inserts_new_object_when_no_match():
+    supabase = StubSupabase()
+    supabase.generated_id = "OBJ-999"
+    agent = IdentityAgent(supabase=supabase, telemetry=EventLog(), llm=DummyLLM())
+
+    payload = {
+        "establishment_name": "Another Establishment",
+        "legacy_ids": ["LEG-XYZ"],
+    }
+    context = AgentContext(
+        coordinator_id="coord",
+        source_payload={"provider_organization_id": "ORG-123"},
+    )
+
+    result = await agent.handle(payload, context)
+
+    assert result["object_id"] == "OBJ-999"
+    assert result["duplicate_of"] is None
+    assert context.object_id == "OBJ-999"
+    assert context.duplicate_of is None
+    assert supabase.external_calls == [
+        {"object_id": "OBJ-999", "organization_id": "ORG-123", "external_ids": ["LEG-XYZ"]}
+    ]

--- a/migration-tool/tests/test_payload_normalisation.py
+++ b/migration-tool/tests/test_payload_normalisation.py
@@ -1,0 +1,174 @@
+"""Tests covering normalisation of legacy payload envelopes."""
+
+from __future__ import annotations
+
+import pytest
+
+from migration_tool.schemas import RawEstablishmentPayload
+
+
+def _sample_payload() -> list[dict[str, object]]:
+    return [
+        {
+            "dataProvidingOrg": "ORGRUN000001",
+            "data": [
+                {
+                    "Nom_OTI": "Le Relais Commerson",
+                    "Groupe catégorie": "Restauration",
+                    "Nom catégorie": "Restaurant",
+                    "Nom sous catégorie": "Restaurant",
+                    "Numéro": "37",
+                    "rue": "rue Boisjoly Potier",
+                    "Code Postal": 97418,
+                    "ville": "Le Tampon",
+                    "Coordonnées GPS": "-21.204197, 55.577417",
+                    "E-Mail": "info@example.com",
+                    "Contact principale": "0262275287",
+                    "Autre téléphone": "0692600544",
+                    "Web": "https://example.com",
+                    "Prestations sur place": "parking, wifi",
+                    "Descriptif OTI": "Description",
+                    "Accroche OTI": "Summary",
+                    "Status": "Ouvert",
+                    "Handicap": True,
+                    "Animaux": False,
+                    "id OTI": "ABC123",
+                },
+                {
+                    "data": [
+                        {
+                            "Presta ID": "P001",
+                            "Nom": "Adenor",
+                            "Prénom": "Jean-Luc",
+                            "Email": "jean@example.com",
+                        }
+                    ]
+                },
+                {
+                    "data": [
+                        {
+                            "Horaires_id": "H001",
+                            "jours": "Lundi , Mardi",
+                            "AM_Start": "09:00",
+                            "AM_Finish": "17:00",
+                        }
+                    ]
+                },
+                {
+                    "data": [
+                        {
+                            "id_multimedia": "M001",
+                            "lien": "https://example.com/photo.jpg",
+                            "type": "image/jpeg",
+                            "description": "Exterior",
+                            "principale": True,
+                        }
+                    ]
+                },
+                {
+                    "data": [
+                        {
+                            "Type_R_S": "facebook",
+                            "URL": "https://facebook.com/relais",
+                        }
+                    ]
+                },
+            ],
+        }
+    ]
+
+
+def test_raw_payload_is_normalised() -> None:
+    payload = RawEstablishmentPayload.model_validate(_sample_payload())
+
+    assert payload.establishment_name == "Le Relais Commerson"
+    assert payload.establishment_category == "Restaurant"
+    assert payload.establishment_subcategory == "Restaurant"
+    assert payload.source_organization_id == "ORGRUN000001"
+    assert "ABC123" in payload.legacy_ids
+
+    data = payload.data
+    assert data["address_line1"].startswith("37")
+    assert data["city"] == "Le Tampon"
+    assert pytest.approx(data["latitude"], rel=1e-3) == -21.204
+    assert "parking" in data["amenities"]
+    assert any(media_item["url"].startswith("https://example.com") for media_item in data["media"])
+    assert data["providers"][0]["Presta ID"] == "P001"
+    assert data["schedule"][0]["Horaires_id"] == "H001"
+    assert data["socials"][0]["network"] == "facebook"
+
+
+def test_payload_from_json_string() -> None:
+    json_payload = """
+    [
+      {
+        "name": "Le Relais Commerson",
+        "category": "Restaurant",
+        "subcategory": "Restaurant",
+        "dataProvidingOrg": "ORGRUN000001",
+        "data": {
+          "address_line1": "37 rue Boisjoly Potier",
+          "city": "Le Tampon",
+          "latitude": -21.204197,
+          "longitude": 55.577417
+        }
+      }
+    ]
+    """
+
+    payload = RawEstablishmentPayload.model_validate(json_payload)
+
+    assert payload.establishment_name == "Le Relais Commerson"
+    assert payload.establishment_category == "Restaurant"
+    assert payload.data["city"] == "Le Tampon"
+
+
+def test_payload_from_xml_string() -> None:
+    xml_payload = """
+    <establishment>
+        <name>Le Relais Commerson</name>
+        <category>Restaurant</category>
+        <subcategory>Restaurant</subcategory>
+        <dataProvidingOrg>ORGRUN000001</dataProvidingOrg>
+        <data>
+            <address_line1>37 rue Boisjoly Potier</address_line1>
+            <city>Le Tampon</city>
+            <latitude>-21.204197</latitude>
+            <longitude>55.577417</longitude>
+        </data>
+    </establishment>
+    """
+
+    payload = RawEstablishmentPayload.model_validate(xml_payload)
+
+    assert payload.establishment_name == "Le Relais Commerson"
+    assert payload.establishment_category == "Restaurant"
+    assert pytest.approx(-21.204197, rel=1e-3) == payload.data["latitude"]
+    assert payload.data["raw_xml_tag"] == "establishment"
+
+
+def test_payload_from_plain_text() -> None:
+    text_payload = """
+    Nom_OTI: Le Relais Commerson
+    Groupe catégorie: Restauration
+    Nom catégorie: Restaurant
+    Nom sous catégorie: Restaurant
+    dataProvidingOrg: ORGRUN000001
+    Numéro: 37
+    rue: rue Boisjoly Potier
+    ville: Le Tampon
+    Coordonnées GPS: -21.204197, 55.577417
+    E-Mail: info@example.com
+    Contact principale: 0262275287
+    """
+
+    payload = RawEstablishmentPayload.model_validate(text_payload)
+
+    assert payload.establishment_name == "Le Relais Commerson"
+    assert payload.establishment_category in {"Restauration", "Restaurant"}
+    assert payload.data["city"] == "Le Tampon"
+    phone_field = payload.data["phone"]
+    if isinstance(phone_field, list):
+        assert "0262275287" in phone_field
+    else:
+        assert "0262275287" in str(phone_field)


### PR DESCRIPTION
## Summary
- extend the payload normaliser to coerce JSON strings, XML documents and key-value text while preserving the raw input
- ensure latitude/longitude, legacy identifiers and top-level fields are extracted so downstream agents receive structured data
- add regression coverage for ingesting JSON text, XML and plain text payloads

## Testing
- pytest tests/test_payload_normalisation.py
- pytest tests/test_identity_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68d53ad00ba88327add42dd46f9eb31e