### PR TITLE
Install AI extras in Docker image

### DIFF
--- a/migration-tool/Dockerfile
+++ b/migration-tool/Dockerfile
@@ -18,7 +18,7 @@ COPY pyproject.toml README.md ./
 COPY migration_tool ./migration_tool
 
 RUN pip install --upgrade pip \
-    && pip install .
+    && pip install '.[ai]'
 
 EXPOSE 8090
 

--- a/migration-tool/migration_tool/agents/amenities.py
+++ b/migration-tool/migration_tool/agents/amenities.py
@@ -38,7 +38,11 @@ class AmenitiesAgent(AIEnabledAgent):
         )
         responses = []
         for amenity in amenities:
-            amenity_id = await self.supabase.lookup("ref_amenity", code=amenity.amenity_code)
+            amenity_id = await self.supabase.ensure_amenity(
+                code=amenity.amenity_code,
+                name=amenity.amenity_name or amenity.raw_label,
+                family_code=amenity.amenity_family_code,
+            )
             data = amenity.to_supabase(amenity_id=amenity_id)
             responses.append(
                 await self.supabase.upsert(

--- a/migration-tool/migration_tool/agents/coordinator.py
+++ b/migration-tool/migration_tool/agents/coordinator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 from ..ai import FieldRouter
 from ..schemas import (
@@ -17,9 +17,13 @@ from ..webhook import WebhookNotifier
 from .amenities import AmenitiesAgent
 from .base import Agent
 from .contact import ContactAgent
+from .environment import EnvironmentAgent
 from .identity import IdentityAgent
+from .languages import LanguageAgent
 from .location import LocationAgent
 from .media import MediaAgent
+from .payments import PaymentMethodAgent
+from .pet_policy import PetPolicyAgent
 from .providers import ProviderAgent
 from .schedule import ScheduleAgent
 
@@ -33,6 +37,10 @@ class Coordinator:
         location_agent: LocationAgent,
         contact_agent: ContactAgent,
         amenities_agent: AmenitiesAgent,
+        language_agent: LanguageAgent,
+        payment_agent: PaymentMethodAgent,
+        environment_agent: EnvironmentAgent,
+        pet_policy_agent: PetPolicyAgent,
         media_agent: MediaAgent,
         provider_agent: ProviderAgent,
         schedule_agent: ScheduleAgent,
@@ -45,6 +53,10 @@ class Coordinator:
             "location": location_agent,
             "contact": contact_agent,
             "amenities": amenities_agent,
+            "languages": language_agent,
+            "payments": payment_agent,
+            "environment": environment_agent,
+            "pet_policy": pet_policy_agent,
             "media": media_agent,
             "providers": provider_agent,
             "schedule": schedule_agent,
@@ -60,33 +72,91 @@ class Coordinator:
     async def handle(self, payload: RawEstablishmentPayload) -> tuple[List[RoutedFragment], Dict[str, Any]]:
         coordinator_id = str(uuid.uuid4())
         payload_dict = payload.model_dump(by_alias=True)
-        combined_payload = {**payload_dict, **payload.data}
+        data_section = payload_dict.pop("data", {})
+        if isinstance(data_section, dict):
+            combined_payload = {**payload_dict, **data_section}
+        else:
+            combined_payload = {**payload_dict, "raw_data": data_section}
+        if payload.source_organization_id:
+            combined_payload.setdefault("source_organization_id", payload.source_organization_id)
         decision: FieldRoutingDecision = await self.router.route(
             payload=combined_payload,
             agent_descriptors=[agent.descriptor() for agent in self.agents.values()],
         )
-        context = AgentContext(coordinator_id=coordinator_id, source_payload=payload_dict)
+        context = AgentContext(
+            coordinator_id=coordinator_id,
+            source_payload=combined_payload,
+            object_id=self._extract_initial_object_id(combined_payload, payload.legacy_ids),
+            source_organization_id=payload.source_organization_id,
+        )
         fragments: List[RoutedFragment] = []
 
         self.telemetry.record(
             "coordinator.received",
             {
                 "coordinator_id": coordinator_id,
-                "payload": payload_dict,
+                "payload": combined_payload,
                 "decision": decision.model_dump(),
             },
         )
 
+        processed_agents: set[str] = set()
+
+        identity_agent = self.agents.get("identity")
+        if identity_agent:
+            identity_payload = self._build_identity_payload(
+                base_payload=combined_payload,
+                raw_payload=payload,
+                initial_object_id=context.object_id,
+                section=decision.sections.get("identity"),
+            )
+            if identity_payload:
+                section_payload = self._prepare_section_payload(
+                    identity_payload,
+                    payload,
+                    context.object_id,
+                )
+                try:
+                    result = await identity_agent.handle(section_payload, context)
+                    context.object_id = result.get("object_id") or context.object_id
+                    context.duplicate_of = result.get("duplicate_of") or context.duplicate_of
+                    fragments.append(
+                        RoutedFragment(agent="identity", status="processed", payload=section_payload, message=None)
+                    )
+                    self.telemetry.record(
+                        "coordinator.agent.identity",
+                        {
+                            "coordinator_id": coordinator_id,
+                            "payload": section_payload,
+                            "result": result,
+                        },
+                    )
+                except Exception as exc:
+                    fragments.append(
+                        RoutedFragment(agent="identity", status="error", payload=section_payload, message=str(exc))
+                    )
+                    self.telemetry.record(
+                        "coordinator.agent_error.identity",
+                        {
+                            "coordinator_id": coordinator_id,
+                            "payload": section_payload,
+                            "error": str(exc),
+                        },
+                    )
+                processed_agents.add("identity")
+
         for name, agent in self.agents.items():
+            if name in processed_agents:
+                continue
             section_payload = dict(decision.sections.get(name, {}))
             if not section_payload:
                 continue
 
-            section_payload.setdefault("establishment_id", payload_dict.get("legacy_ids", [None])[0])
-            section_payload.setdefault("establishment_name", payload.establishment_name)
-            section_payload.setdefault("category", payload.establishment_category)
-            section_payload.setdefault("subcategory", payload.establishment_subcategory)
-            section_payload.setdefault("legacy_ids", payload.legacy_ids)
+            section_payload = self._prepare_section_payload(
+                section_payload,
+                payload,
+                context.object_id,
+            )
 
             try:
                 result = await agent.handle(section_payload, context)
@@ -116,5 +186,165 @@ class Coordinator:
 
         return fragments, leftovers
 
+    def _prepare_section_payload(
+        self,
+        section_payload: Dict[str, Any],
+        payload: RawEstablishmentPayload,
+        object_id: Optional[str],
+    ) -> Dict[str, Any]:
+        enriched = dict(section_payload)
+        if object_id:
+            enriched.setdefault("establishment_id", object_id)
+            enriched.setdefault("object_id", object_id)
+        else:
+            enriched.setdefault("establishment_id", None)
+        enriched.setdefault("establishment_name", payload.establishment_name)
+        enriched.setdefault("category", payload.establishment_category)
+        enriched.setdefault("subcategory", payload.establishment_subcategory)
+        if payload.legacy_ids is not None:
+            enriched.setdefault("legacy_ids", payload.legacy_ids)
+        else:
+            enriched.setdefault("legacy_ids", [])
+        if payload.source_organization_id:
+            enriched.setdefault("source_organization_id", payload.source_organization_id)
+        return enriched
 
-__all__ = ["Coordinator"]
+    def _build_identity_payload(
+        self,
+        *,
+        base_payload: Dict[str, Any],
+        raw_payload: RawEstablishmentPayload,
+        initial_object_id: Optional[str],
+        section: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Compose the payload passed to the identity agent.
+
+        The router may fail to assign fields to the identity section when payloads
+        are highly irregular. This helper hydrates a minimal fragment so the
+        identity agent can always attempt to create or reuse the canonical object
+        and return the Supabase-generated identifier for downstream agents.
+        """
+
+        identity_payload: Dict[str, Any] = {}
+        if section:
+            identity_payload.update(section)
+
+        def _set_default(key: str, value: Any) -> None:
+            if value in (None, "", [], {}):
+                return
+            identity_payload.setdefault(key, value)
+
+        _set_default("establishment_name", base_payload.get("establishment_name") or base_payload.get("name"))
+        if raw_payload.establishment_name:
+            identity_payload["establishment_name"] = raw_payload.establishment_name
+
+        _set_default("category", base_payload.get("category"))
+        if raw_payload.establishment_category:
+            identity_payload["category"] = raw_payload.establishment_category
+
+        _set_default("subcategory", base_payload.get("subcategory"))
+        if raw_payload.establishment_subcategory:
+            identity_payload["subcategory"] = raw_payload.establishment_subcategory
+
+        description = (
+            identity_payload.get("description")
+            or base_payload.get("description")
+            or base_payload.get("summary")
+            or base_payload.get("descriptif")
+        )
+        _set_default("description", description)
+
+        existing_legacy = identity_payload.get("legacy_ids") or []
+        if isinstance(existing_legacy, str):
+            existing_legacy = [existing_legacy]
+        legacy_candidates = list(existing_legacy)
+        payload_legacy = raw_payload.legacy_ids or base_payload.get("legacy_ids") or []
+        if isinstance(payload_legacy, str):
+            payload_legacy = [payload_legacy]
+        for candidate in payload_legacy:
+            if candidate and candidate not in legacy_candidates:
+                legacy_candidates.append(candidate)
+        identity_payload["legacy_ids"] = legacy_candidates
+
+        candidate_object_id = (
+            identity_payload.get("establishment_id")
+            or identity_payload.get("object_id")
+            or base_payload.get("establishment_id")
+            or base_payload.get("object_id")
+            or initial_object_id
+        )
+        if candidate_object_id:
+            identity_payload.setdefault("establishment_id", candidate_object_id)
+
+        if base_payload:
+            _set_default("source_payload", base_payload)
+
+        return identity_payload if identity_payload.get("establishment_name") else {}
+
+    @staticmethod
+    def _extract_initial_object_id(
+        payload: Dict[str, Any],
+        legacy_ids: Optional[Sequence[str]],
+    ) -> Optional[str]:
+        for key in ("object_id", "establishment_id", "id"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+        if legacy_ids:
+            for candidate in legacy_ids:
+                if candidate:
+                    return str(candidate)
+        return None
+
+
+RECOGNISED_FIELDS: Dict[str, List[str]] = {
+    "identity": [
+        "establishment_name",
+        "establishment_id",
+        "object_id",
+        "category",
+        "subcategory",
+        "legacy_ids",
+        "description",
+    ],
+    "location": [
+        "address_line1",
+        "address_line2",
+        "postcode",
+        "postal_code",
+        "city",
+        "latitude",
+        "longitude",
+        "code_insee",
+    ],
+    "contact": ["phone", "email", "website"],
+    "amenities": ["amenities"],
+    "languages": ["languages"],
+    "payments": ["payment_methods"],
+    "environment": ["environment_tags"],
+    "pet_policy": ["pets_allowed"],
+    "media": ["media"],
+    "providers": ["providers"],
+    "schedule": ["schedule", "horaires"],
+}
+
+
+def partition_payload(payload: Dict[str, Any]) -> tuple[Dict[str, Dict[str, Any]], Dict[str, Any]]:
+    sections: Dict[str, Dict[str, Any]] = {agent: {} for agent in RECOGNISED_FIELDS}
+    leftovers: Dict[str, Any] = {}
+
+    for key, value in payload.items():
+        assigned = False
+        for agent, fields in RECOGNISED_FIELDS.items():
+            if key in fields:
+                sections[agent][key] = value
+                assigned = True
+                break
+        if not assigned:
+            leftovers[key] = value
+
+    sections = {agent: data for agent, data in sections.items() if data}
+    return sections, leftovers
+
+
+__all__ = ["Coordinator", "partition_payload", "RECOGNISED_FIELDS"]

--- a/migration-tool/migration_tool/agents/environment.py
+++ b/migration-tool/migration_tool/agents/environment.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..ai import LLMClient
+from ..schemas import AgentContext, EnvironmentTagTransformation
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import AIEnabledAgent
+
+
+class EnvironmentAgent(AIEnabledAgent):
+    """Agent that links environment/localisation tags to objects."""
+
+    name = "environment"
+    description = "Registers environment tags describing the establishment context."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog, llm: LLMClient) -> None:
+        super().__init__(llm)
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = ["environment_tags", "localisations", "environment"]
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        transformation = await self.llm.transform_fragment(
+            agent_name=self.name,
+            payload=payload,
+            response_model=EnvironmentTagTransformation,
+        )
+        responses = []
+        for record in transformation.environment_tags:
+            environment_code = (record.environment_code or "").strip()
+            if not environment_code and record.environment_name:
+                environment_code = self.supabase.normalize_code(record.environment_name)
+            if not environment_code:
+                continue
+
+            tag_id = await self.supabase.ensure_code(
+                domain="environment_tag",
+                code=environment_code,
+                name=record.environment_name or environment_code.replace("_", " ").title(),
+            )
+            data = record.to_supabase(environment_tag_id=tag_id)
+            responses.append(
+                await self.supabase.upsert(
+                    "object_environment_tag",
+                    data,
+                    on_conflict="object_id,environment_tag_id",
+                )
+            )
+
+        self.telemetry.record(
+            "agent.environment.transform",
+            {
+                "context": context.model_dump(),
+                "payload": payload,
+                "environment_tags": [record.model_dump() for record in transformation.environment_tags],
+            },
+        )
+
+        return {
+            "status": "ok",
+            "operation": "upsert",
+            "table": "object_environment_tag",
+            "responses": responses,
+        }
+
+
+__all__ = ["EnvironmentAgent"]

--- a/migration-tool/migration_tool/agents/identity.py
+++ b/migration-tool/migration_tool/agents/identity.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+import re
+from typing import Any, Dict, Optional, Tuple
 
 from ..ai import LLMClient
 from ..schemas import AgentContext, IdentityRecord
@@ -35,17 +36,172 @@ class IdentityAgent(AIEnabledAgent):
             response_model=IdentityRecord,
         )
         data = record.to_supabase()
+
+        matched_existing = None
+        latitude = longitude = None
+        if not record.object_id:
+            latitude, longitude = self._extract_coordinates(context.source_payload)
+            matched_existing = await self.supabase.find_existing_object(
+                name=record.name,
+                latitude=latitude,
+                longitude=longitude,
+                category=record.category_code,
+                subcategory=record.subcategory_code,
+            )
+            if matched_existing and matched_existing.get("id"):
+                record.object_id = matched_existing["id"]
+                data["id"] = matched_existing["id"]
+                context.object_id = matched_existing["id"]
+                context.duplicate_of = matched_existing["id"]
+
         self.telemetry.record(
             "agent.identity.transform",
             {"context": context.model_dump(), "payload": payload, "record": record.model_dump(), "data": data},
         )
+
         response = await self.supabase.upsert("object", data, on_conflict="id")
+        object_id = record.object_id or self._extract_object_id(response)
+        if object_id:
+            record.object_id = object_id
+            context.object_id = object_id
+
+        organization_id = context.source_organization_id or self._extract_organization_id(
+            context.source_payload
+        )
+        external_id_results = []
+        if object_id and organization_id and record.legacy_ids:
+            external_id_results = await self.supabase.record_external_ids(
+                object_id=object_id,
+                organization_id=organization_id,
+                external_ids=record.legacy_ids,
+            )
+
+        if matched_existing:
+            self.telemetry.record(
+                "agent.identity.dedup",
+                {
+                    "context": context.model_dump(),
+                    "matched": matched_existing,
+                    "latitude": latitude,
+                    "longitude": longitude,
+                },
+            )
+
         return {
             "status": "ok",
             "operation": "upsert",
             "table": "object",
             "response": response,
+            "object_id": object_id,
+            "duplicate_of": matched_existing.get("id") if matched_existing else None,
+            "external_ids": external_id_results,
         }
+
+    def _extract_object_id(self, response: Dict[str, Any]) -> Optional[str]:
+        if not isinstance(response, dict):
+            return None
+        data = response.get("data")
+        if isinstance(data, list) and data:
+            first = data[0]
+            if isinstance(first, dict) and first.get("id"):
+                return str(first["id"])
+        if response.get("id"):
+            return str(response["id"])
+        return None
+
+    def _extract_coordinates(self, payload: Dict[str, Any]) -> Tuple[Optional[float], Optional[float]]:
+        latitude: Optional[float] = None
+        longitude: Optional[float] = None
+
+        if not payload:
+            return None, None
+
+        def coerce(value: Any) -> Optional[float]:
+            if value is None:
+                return None
+            try:
+                text = str(value).strip().replace(",", ".")
+                if not text:
+                    return None
+                return float(text)
+            except (TypeError, ValueError):
+                return None
+
+        def parse_string(key: str, value: str) -> None:
+            nonlocal latitude, longitude
+            key_lower = key.lower()
+            if not any(token in key_lower for token in ("lat", "lon", "lng", "coord", "gps")):
+                return
+            matches = re.findall(r"-?\d+(?:[\.,]\d+)?", value)
+            if len(matches) >= 2:
+                if latitude is None:
+                    latitude = coerce(matches[0])
+                if longitude is None:
+                    longitude = coerce(matches[1])
+
+        def visit(obj: Any, key: str = "") -> None:
+            nonlocal latitude, longitude
+            if latitude is not None and longitude is not None:
+                return
+            if isinstance(obj, dict):
+                for child_key, child_value in obj.items():
+                    visit(child_value, child_key)
+            elif isinstance(obj, (list, tuple)):
+                for item in obj:
+                    visit(item, key)
+            elif isinstance(obj, str):
+                parse_string(key, obj)
+                if latitude is None or longitude is None:
+                    if "," in obj or ";" in obj:
+                        parts = re.split(r"[,;]", obj)
+                        if len(parts) >= 2:
+                            lat_candidate = coerce(parts[0])
+                            lon_candidate = coerce(parts[1])
+                            latitude = latitude or lat_candidate
+                            longitude = longitude or lon_candidate
+            else:
+                key_lower = key.lower()
+                value = coerce(obj)
+                if value is not None:
+                    if "lat" in key_lower and latitude is None:
+                        latitude = value
+                    elif any(token in key_lower for token in ("lon", "lng", "long")) and longitude is None:
+                        longitude = value
+
+        visit(payload)
+        return latitude, longitude
+
+    def _extract_organization_id(self, payload: Dict[str, Any]) -> Optional[str]:
+        candidate_keys = (
+            "organization_id",
+            "organization_object_id",
+            "source_organization_id",
+            "dataprovidingorg",
+            "provider_id",
+            "provider_organization_id",
+            "owner_id",
+        )
+
+        def visit(obj: Any) -> Optional[str]:
+            if isinstance(obj, dict):
+                for key, value in obj.items():
+                    key_lower = key.lower()
+                    if any(candidate in key_lower for candidate in candidate_keys):
+                        if isinstance(value, (str, int)):
+                            text = str(value).strip()
+                            if text:
+                                return text
+                    result = visit(value)
+                    if result:
+                        return result
+            elif isinstance(obj, (list, tuple)):
+                for item in obj:
+                    result = visit(item)
+                    if result:
+                        return result
+            return None
+
+        return visit(payload or {})
 
 
 __all__ = ["IdentityAgent"]

--- a/migration-tool/migration_tool/agents/languages.py
+++ b/migration-tool/migration_tool/agents/languages.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from ..ai import LLMClient
+from ..schemas import AgentContext, LanguageTransformation
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import AIEnabledAgent
+
+
+class LanguageAgent(AIEnabledAgent):
+    """Agent responsible for linking spoken languages to objects."""
+
+    name = "languages"
+    description = "Registers spoken languages for the establishment."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog, llm: LLMClient) -> None:
+        super().__init__(llm)
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = ["languages", "langues", "spoken_languages"]
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        transformation = await self.llm.transform_fragment(
+            agent_name=self.name,
+            payload=payload,
+            response_model=LanguageTransformation,
+        )
+        responses = []
+        for record in transformation.languages:
+            language_code = (record.language_code or "").strip()
+            if not language_code and record.language_name:
+                language_code = self.supabase.normalize_code(record.language_name)
+            if not language_code:
+                continue
+
+            language_id = await self.supabase.ensure_language(
+                code=language_code,
+                name=record.language_name,
+            )
+            level_id: Optional[str] = None
+            if record.proficiency_code:
+                level_id = await self.supabase.ensure_code(
+                    domain="language_level",
+                    code=record.proficiency_code,
+                    name=record.proficiency_code.replace("_", " ").title(),
+                )
+
+            data = record.to_supabase(language_id=language_id, level_id=level_id)
+            responses.append(
+                await self.supabase.upsert(
+                    "object_language",
+                    data,
+                    on_conflict="object_id,language_id",
+                )
+            )
+
+        self.telemetry.record(
+            "agent.languages.transform",
+            {
+                "context": context.model_dump(),
+                "payload": payload,
+                "languages": [record.model_dump() for record in transformation.languages],
+            },
+        )
+
+        return {
+            "status": "ok",
+            "operation": "upsert",
+            "table": "object_language",
+            "responses": responses,
+        }
+
+
+__all__ = ["LanguageAgent"]

--- a/migration-tool/migration_tool/agents/payments.py
+++ b/migration-tool/migration_tool/agents/payments.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..ai import LLMClient
+from ..schemas import AgentContext, PaymentMethodTransformation
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import AIEnabledAgent
+
+
+class PaymentMethodAgent(AIEnabledAgent):
+    """Agent that links accepted payment methods to the object."""
+
+    name = "payments"
+    description = "Registers accepted payment methods for the establishment."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog, llm: LLMClient) -> None:
+        super().__init__(llm)
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = ["payment_methods", "mode_de_paiement"]
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        transformation = await self.llm.transform_fragment(
+            agent_name=self.name,
+            payload=payload,
+            response_model=PaymentMethodTransformation,
+        )
+        responses = []
+        for record in transformation.payment_methods:
+            payment_code = (record.payment_code or "").strip()
+            if not payment_code and record.payment_name:
+                payment_code = self.supabase.normalize_code(record.payment_name)
+            if not payment_code:
+                continue
+
+            method_id = await self.supabase.ensure_code(
+                domain="payment_method",
+                code=payment_code,
+                name=record.payment_name or payment_code.replace("_", " ").title(),
+            )
+            data = record.to_supabase(payment_method_id=method_id)
+            responses.append(
+                await self.supabase.upsert(
+                    "object_payment_method",
+                    data,
+                    on_conflict="object_id,payment_method_id",
+                )
+            )
+
+        self.telemetry.record(
+            "agent.payments.transform",
+            {
+                "context": context.model_dump(),
+                "payload": payload,
+                "payment_methods": [record.model_dump() for record in transformation.payment_methods],
+            },
+        )
+
+        return {
+            "status": "ok",
+            "operation": "upsert",
+            "table": "object_payment_method",
+            "responses": responses,
+        }
+
+
+__all__ = ["PaymentMethodAgent"]

--- a/migration-tool/migration_tool/agents/pet_policy.py
+++ b/migration-tool/migration_tool/agents/pet_policy.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..ai import LLMClient
+from ..schemas import AgentContext, PetPolicyTransformation
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import AIEnabledAgent
+
+
+class PetPolicyAgent(AIEnabledAgent):
+    """Agent that records pet policy information for an establishment."""
+
+    name = "pet_policy"
+    description = "Stores whether pets are accepted and associated notes."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog, llm: LLMClient) -> None:
+        super().__init__(llm)
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = ["pets_allowed", "pet_policy", "animaux"]
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        transformation = await self.llm.transform_fragment(
+            agent_name=self.name,
+            payload=payload,
+            response_model=PetPolicyTransformation,
+        )
+        record = transformation.pet_policy
+        if not record or record.accepted is None and not record.conditions:
+            return {
+                "status": "ok",
+                "operation": "no_data",
+                "message": "No pet policy information provided",
+            }
+
+        data = record.to_supabase()
+        response = await self.supabase.upsert(
+            "object_pet_policy",
+            data,
+            on_conflict="object_id",
+        )
+
+        self.telemetry.record(
+            "agent.pet_policy.transform",
+            {
+                "context": context.model_dump(),
+                "payload": payload,
+                "pet_policy": record.model_dump() if record else None,
+            },
+        )
+
+        return {
+            "status": "ok",
+            "operation": "upsert",
+            "table": "object_pet_policy",
+            "response": response,
+        }
+
+
+__all__ = ["PetPolicyAgent"]

--- a/migration-tool/migration_tool/ai.py
+++ b/migration-tool/migration_tool/ai.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import abc
 import json
 import re
+import warnings
 from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 from pydantic import BaseModel
+
+import unicodedata
 
 from .schemas import (
     AgentDescriptor,
@@ -15,13 +18,21 @@ from .schemas import (
     AmenityTransformation,
     ContactChannelRecord,
     ContactTransformation,
+    EnvironmentTagRecord,
+    EnvironmentTagTransformation,
     FieldAssignment,
     FieldRoutingDecision,
     IdentityRecord,
+    LanguageLinkRecord,
+    LanguageTransformation,
     LocationRecord,
     LocationTransformation,
     MediaRecord,
     MediaTransformation,
+    PaymentMethodRecord,
+    PaymentMethodTransformation,
+    PetPolicyRecord,
+    PetPolicyTransformation,
 )
 
 try:  # pragma: no cover - optional dependency
@@ -65,13 +76,65 @@ class RuleBasedLLM(LLMClient):
     name = "rule-based"
 
     FIELD_KEYWORDS: Dict[str, Iterable[str]] = {
-        "identity": ("name", "title", "category", "sub_category", "legacy", "description", "type"),
-        "location": ("address", "postal", "zip", "city", "country", "latitude", "longitude", "gps", "insee"),
-        "contact": ("phone", "email", "website", "url", "booking", "contact", "social"),
-        "amenities": ("amenitie", "equipment", "service", "facility"),
-        "media": ("photo", "image", "video", "media", "picture", "logo"),
-        "providers": ("prestataire", "provider", "presta", "nom", "prenom", "gerant", "fonction"),
+        "identity": (
+            "name",
+            "nom",
+            "title",
+            "category",
+            "categorie",
+            "sub_category",
+            "sous_categorie",
+            "legacy",
+            "description",
+            "type",
+            "status",
+        ),
+        "location": (
+            "address",
+            "adresse",
+            "postal",
+            "code_postal",
+            "zip",
+            "city",
+            "ville",
+            "country",
+            "latitude",
+            "longitude",
+            "gps",
+            "insee",
+        ),
+        "contact": (
+            "phone",
+            "telephone",
+            "tel",
+            "mobile",
+            "email",
+            "mail",
+            "website",
+            "site",
+            "url",
+            "booking",
+            "reservation",
+            "contact",
+            "social",
+        ),
+        "amenities": ("amenitie", "amenity", "equipment", "service", "facility", "prestations", "equipement"),
+        "media": ("photo", "image", "video", "media", "picture", "logo", "galerie"),
+        "providers": (
+            "prestataire",
+            "providers",
+            "provider",
+            "presta",
+            "nom",
+            "prenom",
+            "gerant",
+            "fonction",
+        ),
         "schedule": ("horaires", "schedule", "jours", "ouverture", "fermeture", "reservation"),
+        "languages": ("langue", "language", "spoken_language", "idiome"),
+        "payments": ("paiement", "payment", "carte", "cheque", "espèce", "cb", "mode_de_paiement"),
+        "environment": ("environnement", "environment", "localisation", "milieu", "quartier", "village"),
+        "pet_policy": ("animal", "pet", "animaux", "chiens", "chats"),
     }
 
     CATEGORY_TO_OBJECT_TYPE: Dict[str, str] = {
@@ -95,7 +158,10 @@ class RuleBasedLLM(LLMClient):
     CONTACT_KIND_DEFAULTS: Dict[str, str] = {
         "phone": "phone",
         "mobile": "phone",
+        "portable": "phone",
         "téléphone": "phone",
+        "telephone": "phone",
+        "numero": "phone",
         "email": "email",
         "mail": "email",
         "website": "website",
@@ -117,6 +183,41 @@ class RuleBasedLLM(LLMClient):
         "picture": "image",
         "logo": "logo",
         "video": "video",
+    }
+
+    LANGUAGE_ALIASES: Dict[str, str] = {
+        "fr": "fr",
+        "francais": "fr",
+        "français": "fr",
+        "french": "fr",
+        "en": "en",
+        "anglais": "en",
+        "english": "en",
+        "es": "es",
+        "espagnol": "es",
+        "spanish": "es",
+        "de": "de",
+        "allemand": "de",
+        "german": "de",
+        "it": "it",
+        "italien": "it",
+        "italian": "it",
+        "pt": "pt",
+        "portugais": "pt",
+        "portuguese": "pt",
+        "nl": "nl",
+        "neerlandais": "nl",
+        "dutch": "nl",
+        "zh": "zh",
+        "chinois": "zh",
+        "mandarin": "zh",
+        "ru": "ru",
+        "russe": "ru",
+        "ar": "ar",
+        "arabe": "ar",
+        "cr": "cr",
+        "creole": "cr",
+        "créole": "cr",
     }
 
     async def classify_fields(
@@ -166,6 +267,14 @@ class RuleBasedLLM(LLMClient):
             data = self._transform_amenities(payload)
         elif agent_name == "media":
             data = self._transform_media(payload)
+        elif agent_name == "languages":
+            data = self._transform_languages(payload)
+        elif agent_name == "payments":
+            data = self._transform_payments(payload)
+        elif agent_name == "environment":
+            data = self._transform_environment(payload)
+        elif agent_name == "pet_policy":
+            data = self._transform_pet_policy(payload)
         elif agent_name == "providers":
             data = self._transform_providers(payload)
         elif agent_name == "schedule":
@@ -177,13 +286,16 @@ class RuleBasedLLM(LLMClient):
             return data
         return response_model.model_validate(data)
 
+    def _strip_accents(self, value: str) -> str:
+        return "".join(ch for ch in unicodedata.normalize("NFKD", value) if not unicodedata.combining(ch))
+
     def _guess_agent(
         self,
         key: str,
         value: Any,
         available_agents: Iterable[str],
     ) -> Optional[str]:
-        lowered = key.lower()
+        lowered = self._strip_accents(key).lower()
         for agent_name, keywords in self.FIELD_KEYWORDS.items():
             if agent_name not in available_agents:
                 continue
@@ -275,10 +387,13 @@ class RuleBasedLLM(LLMClient):
         channels: List[ContactChannelRecord] = []
 
         for key, value in payload.items():
-            normalized_key = key.lower()
+            normalized_key = self._strip_accents(key).lower()
             if isinstance(value, dict):
                 for nested_key, nested_value in value.items():
-                    channels.extend(self._create_contact_channels(object_id, nested_key, nested_value))
+                    nested_normalized = self._strip_accents(str(nested_key)).lower()
+                    channels.extend(
+                        self._create_contact_channels(object_id, nested_normalized, nested_value)
+                    )
             else:
                 channels.extend(self._create_contact_channels(object_id, normalized_key, value))
 
@@ -286,16 +401,28 @@ class RuleBasedLLM(LLMClient):
 
     def _transform_amenities(self, payload: Dict[str, Any]) -> AmenityTransformation:
         object_id = payload.get("establishment_id") or payload.get("object_id")
-        amenities = payload.get("amenities") or payload.get("equipment") or payload.get("services") or []
+        amenities = (
+            payload.get("amenities")
+            or payload.get("equipment")
+            or payload.get("services")
+            or payload.get("prestations")
+            or []
+        )
         if isinstance(amenities, str):
             amenities = re.split(r",|;|/", amenities)
         links = []
         for amenity in amenities:
             if not amenity:
                 continue
-            code = _normalize(str(amenity))
+            label = str(amenity).strip()
+            code = _normalize(label)
             links.append(
-                AmenityLinkRecord(object_id=object_id, amenity_code=code, raw_label=str(amenity).strip())
+                AmenityLinkRecord(
+                    object_id=object_id,
+                    amenity_code=code,
+                    amenity_name=label or None,
+                    raw_label=label or None,
+                )
             )
         return AmenityTransformation(amenities=links)
 
@@ -326,6 +453,136 @@ class RuleBasedLLM(LLMClient):
                     )
                 )
         return MediaTransformation(media=records)
+
+    def _transform_languages(self, payload: Dict[str, Any]) -> LanguageTransformation:
+        object_id = payload.get("establishment_id") or payload.get("object_id")
+        languages_raw = payload.get("languages") or payload.get("langues") or []
+        if isinstance(languages_raw, dict):
+            languages_iterable = languages_raw.values()
+        else:
+            languages_iterable = self._split_items(languages_raw)
+
+        records = []
+        for language in languages_iterable:
+            label = str(language).strip()
+            if not label:
+                continue
+            code = self._guess_language_code(label)
+            records.append(
+                LanguageLinkRecord(
+                    object_id=object_id,
+                    language_code=code,
+                    language_name=label,
+                )
+            )
+        return LanguageTransformation(languages=records)
+
+    def _guess_language_code(self, label: str) -> str:
+        normalized = self._strip_accents(label).lower().strip()
+        normalized = normalized.replace("-", "_").replace(" ", "_")
+        if normalized in self.LANGUAGE_ALIASES:
+            return self.LANGUAGE_ALIASES[normalized]
+        if len(normalized) == 2 and normalized.isalpha():
+            return normalized
+        if "_" in normalized:
+            prefix = normalized.split("_", 1)[0]
+            if len(prefix) == 2 and prefix.isalpha():
+                return prefix
+        if len(normalized) >= 3 and normalized[:2].isalpha():
+            return normalized[:2]
+        return normalized or "und"
+
+    def _transform_payments(self, payload: Dict[str, Any]) -> PaymentMethodTransformation:
+        object_id = payload.get("establishment_id") or payload.get("object_id")
+        payments_raw = payload.get("payment_methods") or payload.get("mode_de_paiement") or []
+        records = []
+        for item in self._split_items(payments_raw):
+            label = str(item).strip()
+            if not label:
+                continue
+            code = _normalize(label)
+            records.append(
+                PaymentMethodRecord(
+                    object_id=object_id,
+                    payment_code=code,
+                    payment_name=label,
+                )
+            )
+        return PaymentMethodTransformation(payment_methods=records)
+
+    def _transform_environment(self, payload: Dict[str, Any]) -> EnvironmentTagTransformation:
+        object_id = payload.get("establishment_id") or payload.get("object_id")
+        environment_raw = (
+            payload.get("environment_tags")
+            or payload.get("localisations")
+            or payload.get("environment")
+            or []
+        )
+        records = []
+        for item in self._split_items(environment_raw):
+            label = str(item).strip()
+            if not label:
+                continue
+            code = _normalize(label)
+            records.append(
+                EnvironmentTagRecord(
+                    object_id=object_id,
+                    environment_code=code,
+                    environment_name=label,
+                )
+            )
+        return EnvironmentTagTransformation(environment_tags=records)
+
+    def _transform_pet_policy(self, payload: Dict[str, Any]) -> PetPolicyTransformation:
+        object_id = payload.get("establishment_id") or payload.get("object_id")
+        pet_payload = payload.get("pet_policy") if isinstance(payload.get("pet_policy"), dict) else {}
+        accepted_raw = pet_payload.get("accepted")
+        if accepted_raw is None:
+            accepted_raw = payload.get("pets_allowed")
+        if accepted_raw is None:
+            accepted_raw = payload.get("animaux")
+        conditions = pet_payload.get("conditions") or payload.get("pet_policy_notes")
+        accepted = self._coerce_bool(accepted_raw)
+        if accepted is None and conditions is None:
+            return PetPolicyTransformation(pet_policy=None)
+        record = PetPolicyRecord(
+            object_id=object_id,
+            accepted=accepted,
+            conditions=conditions,
+        )
+        return PetPolicyTransformation(pet_policy=record)
+
+    def _split_items(self, value: Any) -> List[Any]:
+        if value in (None, "", []):
+            return []
+        if isinstance(value, list):
+            return [item for item in value if item not in (None, "")]
+        if isinstance(value, tuple):
+            return [item for item in value if item not in (None, "")]
+        if isinstance(value, set):
+            return [item for item in value if item not in (None, "")]
+        if isinstance(value, dict):
+            return [item for item in value.values() if item not in (None, "")]
+        if isinstance(value, str):
+            parts = re.split(r"[,;/|]", value)
+            return [part.strip() for part in parts if part.strip()]
+        return [value]
+
+    def _coerce_bool(self, value: Any) -> Optional[bool]:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            if value == 1:
+                return True
+            if value == 0:
+                return False
+        if isinstance(value, str):
+            normalized = self._strip_accents(value).strip().lower()
+            if normalized in {"oui", "yes", "true", "1", "allowed", "autorise"}:
+                return True
+            if normalized in {"non", "no", "false", "0", "forbidden", "interdit"}:
+                return False
+        return None
 
     def _guess_object_type(self, category: str) -> str:
         if not category:
@@ -360,6 +617,12 @@ class RuleBasedLLM(LLMClient):
             return entries
 
         kind_code = self._infer_contact_kind(key)
+        if isinstance(value, str):
+            trimmed = value.strip()
+            if "@" in trimmed and not trimmed.startswith("http"):
+                kind_code = "email"
+            elif re.search(r"\d{2}", trimmed):
+                kind_code = "phone" if kind_code == "other" else kind_code
         if isinstance(value, (list, tuple)):
             for item in value:
                 if item:
@@ -404,13 +667,46 @@ class RuleBasedLLM(LLMClient):
         
         providers = []
         object_provider_links = []
-        
+
         for provider_data in providers_data:
             if not isinstance(provider_data, dict):
                 continue
-                
+
+            postcode_raw = provider_data.get("Code Postal") or provider_data.get("postcode")
+            postcode_value = str(postcode_raw) if postcode_raw not in (None, "") else None
+
+            provider_identifier_candidates = [
+                provider_data.get("provider_id"),
+                provider_data.get("providerId"),
+                provider_data.get("id"),
+                provider_data.get("provider_uuid"),
+            ]
+            provider_identifier = next(
+                (
+                    str(candidate)
+                    for candidate in provider_identifier_candidates
+                    if candidate not in (None, "")
+                ),
+                None,
+            )
+
+            legacy_identifiers: List[str] = []
+            for key in ("Presta ID", "Temp_form_ID"):
+                value = provider_data.get(key)
+                if value:
+                    legacy_identifiers.append(str(value))
+            existing_legacy = provider_data.get("legacy_ids")
+            if isinstance(existing_legacy, (list, tuple)):
+                for item in existing_legacy:
+                    if item:
+                        legacy_identifiers.append(str(item))
+            elif isinstance(existing_legacy, str) and existing_legacy.strip():
+                legacy_identifiers.append(existing_legacy.strip())
+
+            legacy_identifiers = list(dict.fromkeys(legacy_identifiers))
+
             provider_record = ProviderRecord(
-                provider_id=provider_data.get("Presta ID") or provider_data.get("provider_id"),
+                provider_id=provider_identifier,
                 last_name=provider_data.get("Nom") or provider_data.get("last_name") or "",
                 first_name=provider_data.get("Prénom") or provider_data.get("first_name") or "",
                 gender=provider_data.get("Genre") or provider_data.get("gender"),
@@ -419,14 +715,14 @@ class RuleBasedLLM(LLMClient):
                 function=provider_data.get("Fonction") or provider_data.get("function"),
                 newsletter=provider_data.get("Newsletter", False),
                 address1=provider_data.get("rue") or provider_data.get("address1"),
-                postcode=provider_data.get("Code Postal") or provider_data.get("postcode"),
+                postcode=postcode_value,
                 city=provider_data.get("ville") or provider_data.get("city"),
                 lieu_dit=provider_data.get("Lieux-dits") or provider_data.get("lieu_dit"),
                 date_of_birth=provider_data.get("DOB") or provider_data.get("date_of_birth"),
                 revenue=provider_data.get("Revenus") or provider_data.get("revenue"),
-                legacy_ids=[provider_data.get("Presta ID")] if provider_data.get("Presta ID") else [],
+                legacy_ids=legacy_identifiers,
             )
-            
+
             if provider_record.last_name and provider_record.first_name:
                 providers.append(provider_record)
                 if establishment_id and provider_record.provider_id:
@@ -615,7 +911,17 @@ def build_llm(
     if provider == "openai":  # pragma: no cover - requires network access
         if not api_key:
             raise RuntimeError("OpenAI provider selected but no API key was provided.")
-        return OpenAILLM(api_key=api_key, model=model, temperature=temperature)
+        try:
+            return OpenAILLM(api_key=api_key, model=model, temperature=temperature)
+        except RuntimeError as exc:
+            message = str(exc)
+            if "openai" not in message.lower():
+                raise
+            warnings.warn(
+                "OpenAI provider unavailable (missing dependency); falling back to rule-based heuristics.",
+                RuntimeWarning,
+            )
+            return RuleBasedLLM()
 
     if provider in {"auto", "default"}:
         if api_key:

--- a/migration-tool/migration_tool/main.py
+++ b/migration-tool/migration_tool/main.py
@@ -13,9 +13,13 @@ from fastapi.templating import Jinja2Templates
 from .agents.amenities import AmenitiesAgent
 from .agents.contact import ContactAgent
 from .agents.coordinator import Coordinator
+from .agents.environment import EnvironmentAgent
 from .agents.identity import IdentityAgent
+from .agents.languages import LanguageAgent
 from .agents.location import LocationAgent
 from .agents.media import MediaAgent
+from .agents.payments import PaymentMethodAgent
+from .agents.pet_policy import PetPolicyAgent
 from .agents.providers import ProviderAgent
 from .agents.schedule import ScheduleAgent
 from .ai import FieldRouter, build_llm
@@ -46,6 +50,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         location_agent=LocationAgent(supabase, telemetry, llm),
         contact_agent=ContactAgent(supabase, telemetry, llm),
         amenities_agent=AmenitiesAgent(supabase, telemetry, llm),
+        language_agent=LanguageAgent(supabase, telemetry, llm),
+        payment_agent=PaymentMethodAgent(supabase, telemetry, llm),
+        environment_agent=EnvironmentAgent(supabase, telemetry, llm),
+        pet_policy_agent=PetPolicyAgent(supabase, telemetry, llm),
         media_agent=MediaAgent(supabase, telemetry, llm),
         provider_agent=ProviderAgent(supabase, telemetry, llm),
         schedule_agent=ScheduleAgent(supabase, telemetry, llm),

--- a/migration-tool/migration_tool/schemas.py
+++ b/migration-tool/migration_tool/schemas.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+import json
+import re
+import xml.etree.ElementTree as ET
+from typing import Any, Dict, List, Optional, Sequence
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class RawEstablishmentPayload(BaseModel):
@@ -13,6 +16,7 @@ class RawEstablishmentPayload(BaseModel):
     establishment_name: str = Field(..., alias="name")
     establishment_category: Optional[str] = Field(None, alias="category")
     establishment_subcategory: Optional[str] = Field(None, alias="subcategory")
+    source_organization_id: Optional[str] = Field(None, alias="dataProvidingOrg")
     legacy_ids: Optional[List[str]] = None
     data: Dict[str, Any] = Field(default_factory=dict)
 
@@ -20,6 +24,385 @@ class RawEstablishmentPayload(BaseModel):
         "populate_by_name": True,
         "extra": "allow",
     }
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_payload(cls, value: Any) -> Any:
+        """Normalise legacy list-based payloads into a dictionary."""
+
+        raw_text: Optional[str] = None
+
+        if isinstance(value, (bytes, bytearray)):
+            try:
+                value = value.decode("utf-8")
+            except UnicodeDecodeError:
+                value = value.decode("latin-1", errors="ignore")
+
+        if isinstance(value, str):
+            raw_text = value
+            parsed = cls._parse_string_payload(value)
+            value = parsed
+
+        if isinstance(value, list):
+            pass
+        elif not isinstance(value, dict):
+            value = {"data": {}}
+
+        # Unwrap common envelope keys often injected by workflow orchestrators
+        # (for example n8n) so the remainder of the normalisation logic always
+        # receives the actual establishment payload instead of an opaque wrapper.
+        def _unwrap_envelopes(obj: Any) -> Any:
+            if not isinstance(obj, dict):
+                return obj
+
+            envelope_keys = ("body", "payload", "record", "message", "event")
+            unwrapped = dict(obj)
+
+            changed = True
+            while changed and isinstance(unwrapped, dict):
+                changed = False
+                for key in envelope_keys:
+                    inner = unwrapped.get(key)
+                    if isinstance(inner, dict):
+                        # Preserve sibling metadata while promoting the payload
+                        # fields to the top level.
+                        siblings = {k: v for k, v in unwrapped.items() if k != key}
+                        unwrapped = {**siblings, **inner}
+                        changed = True
+                        break
+                    if isinstance(inner, list):
+                        siblings = {k: v for k, v in unwrapped.items() if k != key}
+                        if siblings:
+                            merged_list = []
+                            for item in inner:
+                                if isinstance(item, dict):
+                                    merged_list.append({**siblings, **item})
+                                else:
+                                    merged_list.append(item)
+                            unwrapped = merged_list
+                        else:
+                            unwrapped = inner
+                        changed = True
+                        break
+            return unwrapped
+
+        value = _unwrap_envelopes(value)
+
+        if isinstance(value, list):
+            pass
+        elif not isinstance(value, dict):
+            value = {"data": {}}
+
+        if isinstance(value, dict):
+            for key in ("SubmitingOrgId", "SubmittingOrgId", "SubmittingOrgID", "submitingOrgId"):
+                if key in value and "dataProvidingOrg" not in value:
+                    value["dataProvidingOrg"] = value[key]
+
+        def _as_list(obj: Any) -> List[Dict[str, Any]]:
+            if isinstance(obj, list):
+                return [item for item in obj if isinstance(item, dict)]
+            if isinstance(obj, dict):
+                return [obj]
+            return []
+
+        def _split_values(raw: Optional[str]) -> List[str]:
+            if not raw:
+                return []
+            if isinstance(raw, str):
+                parts = [item.strip() for item in re.split(r"[,;/]", raw) if item.strip()]
+                return parts
+            if isinstance(raw, (list, tuple)):
+                return [str(item).strip() for item in raw if str(item).strip()]
+            return []
+
+        def _coerce_float(raw_value: Any) -> Optional[float]:
+            if raw_value is None:
+                return None
+            try:
+                text = str(raw_value).strip().replace(",", ".")
+                if not text:
+                    return None
+                return float(text)
+            except (TypeError, ValueError):
+                return None
+
+        def _parse_coordinates(raw: Optional[str]) -> tuple[Optional[float], Optional[float]]:
+            if not raw:
+                return None, None
+            try:
+                parts = re.findall(r"-?\d+(?:[\.,]\d+)?", str(raw))
+                if len(parts) >= 2:
+                    lat = float(parts[0].replace(",", "."))
+                    lon = float(parts[1].replace(",", "."))
+                    return lat, lon
+            except (TypeError, ValueError):
+                return None, None
+            return None, None
+
+        raw_blocks: List[Dict[str, Any]] = []
+
+        if isinstance(value, list):
+            if not value:
+                return {}
+            raw_batch = value
+            primary = value[0]
+            extras = value[1:]
+            if isinstance(primary, dict):
+                value = dict(primary)
+                value.setdefault("data", {})
+                if not isinstance(value["data"], dict):
+                    value["data"] = {}
+                value["data"].setdefault("raw_batch", raw_batch)
+                raw_blocks = _as_list(raw_batch)
+            else:
+                value = {"data": {}}
+            if extras:
+                value.setdefault("data", {})
+                value["data"]["additional_batches"] = extras
+
+        if not isinstance(value, dict):
+            return value
+
+        if "data" in value and not isinstance(value["data"], dict):
+            value["data"] = {}
+
+        if raw_text:
+            value.setdefault("data", {})
+            if isinstance(value["data"], dict) and "raw_payload" not in value["data"]:
+                value["data"]["raw_payload"] = raw_text
+
+        payload_data = value.get("data")
+        queue: List[Dict[str, Any]] = list(raw_blocks) if raw_blocks else _as_list(payload_data)
+        if isinstance(value, dict):
+            top_level = {
+                key: entry
+                for key, entry in value.items()
+                if key not in {"data", "legacy_ids"}
+            }
+            if top_level:
+                queue.insert(0, top_level)
+        main_record: Dict[str, Any] = {}
+        additional_sections: Dict[str, Any] = {}
+
+        while queue:
+            block = queue.pop(0)
+            if not isinstance(block, dict):
+                continue
+            if "data" in block and isinstance(block["data"], list):
+                additional_sections.setdefault("raw_blocks", []).append(block["data"])
+                queue.extend(_as_list(block["data"]))
+                continue
+            if "Presta ID" in block:
+                additional_sections.setdefault("providers", []).append(block)
+                continue
+            if "Horaires_id" in block:
+                additional_sections.setdefault("schedule", []).append(block)
+                continue
+            if "id_multimedia" in block:
+                media_item = {
+                    "url": block.get("lien") or block.get("url"),
+                    "description": block.get("description"),
+                    "title": block.get("description"),
+                    "is_main": block.get("principale"),
+                    "media_type": (block.get("type") or "").split("/")[0],
+                    "metadata": block,
+                }
+                additional_sections.setdefault("media", []).append(media_item)
+                continue
+            if "Id_Tarifs" in block:
+                additional_sections.setdefault("tariffs", []).append(block)
+                continue
+            if "Type_R_S" in block:
+                social_item = {
+                    "network": block.get("Type_R_S"),
+                    "url": block.get("URL"),
+                }
+                additional_sections.setdefault("socials", []).append(social_item)
+                continue
+            main_record.update(block)
+
+        value.setdefault("legacy_ids", [])
+        legacy_candidates = []
+        for key in ("id OTI", "ID_IRT", "Num taxe de séjour", "temp_ID_Presta"):
+            candidate = main_record.get(key)
+            if candidate:
+                legacy_candidates.append(str(candidate))
+        existing_legacy = cls._ensure_sequence(value.get("legacy_ids"))
+        value["legacy_ids"] = list(dict.fromkeys([*existing_legacy, *legacy_candidates]))
+
+        if main_record:
+            value["name"] = value.get("name") or main_record.get("Nom_OTI") or main_record.get("Nom") or main_record.get("Nom établissement")
+            value["category"] = value.get("category") or main_record.get("Nom catégorie") or main_record.get("Groupe catégorie")
+            value["subcategory"] = value.get("subcategory") or main_record.get("Nom sous catégorie")
+
+            address_parts = [str(main_record.get("Numéro")) if main_record.get("Numéro") else None, main_record.get("rue")]
+            address_line1 = " ".join(part for part in address_parts if part).strip() or None
+            latitude, longitude = _parse_coordinates(main_record.get("Coordonnées GPS"))
+            latitude = latitude if latitude is not None else _coerce_float(main_record.get("latitude"))
+            longitude = longitude if longitude is not None else _coerce_float(main_record.get("longitude"))
+
+            description = main_record.get("Descriptif OTI") or main_record.get("Descriptif du plan d'accès")
+            summary = main_record.get("Accroche OTI")
+
+            structured = {
+                "address_line1": address_line1,
+                "address_line2": main_record.get("Lieux-dits"),
+                "postcode": str(main_record.get("Code Postal")) if main_record.get("Code Postal") else None,
+                "city": main_record.get("ville"),
+                "latitude": latitude,
+                "longitude": longitude,
+                "description": description,
+                "summary": summary,
+                "status": main_record.get("Status"),
+                "amenities": _split_values(main_record.get("Prestations sur place")),
+                "nearby_services": _split_values(main_record.get("Prestations à proximité")),
+                "environment_tags": _split_values(main_record.get("Localisations")),
+                "payment_methods": _split_values(main_record.get("Mode de paiement")),
+                "languages": _split_values(main_record.get("Langues")),
+                "email": main_record.get("E-Mail"),
+                "phone": [
+                    phone
+                    for phone in [
+                        main_record.get("Contact principale"),
+                        main_record.get("Autre téléphone"),
+                    ]
+                    if phone
+                ],
+                "website": main_record.get("Web"),
+                "raw_main_record": main_record,
+                "main_media": main_record.get("Main_Img"),
+                "accessibility": main_record.get("Handicap"),
+                "pets_allowed": main_record.get("Animaux"),
+                "source_status": main_record.get("SIT"),
+            }
+
+            value.setdefault("data", {})
+            for key, entry in structured.items():
+                if entry not in (None, [], ""):
+                    value["data"][key] = entry
+
+        if additional_sections:
+            value.setdefault("data", {})
+            for key, entry in additional_sections.items():
+                value["data"][key] = entry
+
+        return value
+
+    @staticmethod
+    def _parse_string_payload(raw: str) -> Any:
+        stripped = raw.strip()
+        if not stripped:
+            return {"data": {"raw_payload": raw}}
+
+        # JSON payloads
+        try:
+            parsed = json.loads(stripped)
+            return parsed
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        # XML payloads
+        try:
+            root = ET.fromstring(stripped)
+        except ET.ParseError:
+            root = None
+
+        if root is not None:
+            parsed_xml = RawEstablishmentPayload._collapse_single_key(
+                RawEstablishmentPayload._etree_to_object(root)
+            )
+            if isinstance(parsed_xml, dict):
+                parsed_xml.setdefault("data", {})
+                if isinstance(parsed_xml["data"], dict):
+                    parsed_xml["data"].setdefault("raw_xml_tag", root.tag)
+                return parsed_xml
+            return {"data": {"raw_payload": raw, "raw_xml_tag": root.tag}}
+
+        # Key-value style text payloads
+        kv_pairs: Dict[str, Any] = {}
+        for line in re.split(r"[\r\n;]+", stripped):
+            if not line.strip():
+                continue
+            if ":" in line:
+                key, value = line.split(":", 1)
+            elif "=" in line:
+                key, value = line.split("=", 1)
+            else:
+                continue
+            key = key.strip()
+            value = value.strip()
+            if key:
+                kv_pairs[key] = value
+
+        if kv_pairs:
+            return kv_pairs
+
+        return {"data": {"raw_payload": raw}}
+
+    @staticmethod
+    def _etree_to_object(element: ET.Element) -> Dict[str, Any]:
+        def convert(node: ET.Element) -> Any:
+            children = list(node)
+            attribs = {f"@{k}": v for k, v in node.attrib.items()}
+            text = (node.text or "").strip()
+
+            if not children:
+                if attribs and text:
+                    attribs["#text"] = text
+                    return attribs
+                if attribs:
+                    return attribs
+                return text or None
+
+            result: Dict[str, Any] = dict(attribs)
+            for child in children:
+                child_value = convert(child)
+                if child.tag in result:
+                    existing = result[child.tag]
+                    if not isinstance(existing, list):
+                        result[child.tag] = [existing]
+                    result[child.tag].append(child_value)
+                else:
+                    result[child.tag] = child_value
+            if text:
+                result.setdefault("#text", text)
+            return result
+
+        return {element.tag: convert(element)}
+
+    @staticmethod
+    def _collapse_single_key(value: Any) -> Any:
+        if isinstance(value, dict) and len(value) == 1:
+            inner_value = next(iter(value.values()))
+            if isinstance(inner_value, dict):
+                return RawEstablishmentPayload._collapse_single_key(inner_value)
+            return inner_value
+        return value
+
+    @staticmethod
+    def _ensure_sequence(value: Any) -> List[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        if isinstance(value, (list, tuple, set)):
+            return [str(item) for item in value if str(item).strip()]
+        if isinstance(value, dict):
+            collected: List[str] = []
+            for item in value.values():
+                if isinstance(item, (list, tuple, set)):
+                    collected.extend(str(child) for child in item if str(child).strip())
+                elif isinstance(item, dict):
+                    collected.extend(RawEstablishmentPayload._ensure_sequence(item))
+                else:
+                    text = str(item).strip()
+                    if text:
+                        collected.append(text)
+            return collected
+        if isinstance(value, Sequence):
+            return [str(item) for item in value if str(item).strip()]
+        text = str(value).strip()
+        return [text] if text else []
 
 
 class RoutedFragment(BaseModel):
@@ -52,6 +435,34 @@ class AgentContext(BaseModel):
 
     coordinator_id: str
     source_payload: Dict[str, Any]
+    object_id: Optional[str] = None
+    duplicate_of: Optional[str] = None
+    source_organization_id: Optional[str] = None
+    provider_registry: Dict[str, str] = Field(default_factory=dict)
+
+    def register_provider(
+        self,
+        *,
+        provider_id: str,
+        email: Optional[str] = None,
+        phone: Optional[str] = None,
+        legacy_ids: Optional[Sequence[str]] = None,
+    ) -> None:
+        """Store provider identifiers so other agents can reuse them."""
+
+        registry = self.provider_registry
+        registry.setdefault(str(provider_id), str(provider_id))
+
+        if email:
+            registry.setdefault(email.strip().lower(), str(provider_id))
+
+        if phone:
+            registry.setdefault(str(phone).strip(), str(provider_id))
+
+        if legacy_ids:
+            for legacy in legacy_ids:
+                if legacy:
+                    registry.setdefault(str(legacy).strip(), str(provider_id))
 
 
 class FieldAssignment(BaseModel):
@@ -98,11 +509,12 @@ class IdentityRecord(BaseModel):
             extra["source_payload"] = self.source_extra
 
         payload = {
-            "id": self.object_id,
             "object_type": self.object_type,
             "name": self.name,
             "status": self.status,
         }
+        if self.object_id:
+            payload["id"] = self.object_id
         if self.region_code:
             payload["region_code"] = self.region_code
         cleaned_extra = {k: v for k, v in extra.items() if v not in (None, [], {}, "")}
@@ -179,6 +591,8 @@ class AmenityLinkRecord(BaseModel):
 
     object_id: Optional[str]
     amenity_code: str
+    amenity_name: Optional[str] = None
+    amenity_family_code: Optional[str] = None
     raw_label: Optional[str] = None
 
     def to_supabase(self, *, amenity_id: Optional[str]) -> Dict[str, Any]:
@@ -191,11 +605,113 @@ class AmenityLinkRecord(BaseModel):
         if not amenity_id:
             payload.setdefault("extra", {})
             payload["extra"]["amenity_code"] = self.amenity_code
+            if self.amenity_name:
+                payload["extra"]["amenity_name"] = self.amenity_name
         return payload
 
 
 class AmenityTransformation(BaseModel):
     amenities: List[AmenityLinkRecord]
+
+
+class LanguageLinkRecord(BaseModel):
+    """Representation of the `object_language` relation."""
+
+    object_id: Optional[str]
+    language_code: str
+    language_name: Optional[str] = None
+    proficiency_code: Optional[str] = None
+
+    def to_supabase(self, *, language_id: Optional[str], level_id: Optional[str]) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"object_id": self.object_id}
+        if language_id:
+            payload["language_id"] = language_id
+        if level_id:
+            payload["level_id"] = level_id
+        extra: Dict[str, Any] = {}
+        if not language_id:
+            extra["language_code"] = self.language_code
+        if self.language_name:
+            extra["language_name"] = self.language_name
+        if self.proficiency_code and not level_id:
+            extra["proficiency_code"] = self.proficiency_code
+        if extra:
+            payload["extra"] = extra
+        return payload
+
+
+class LanguageTransformation(BaseModel):
+    languages: List[LanguageLinkRecord]
+
+
+class PaymentMethodRecord(BaseModel):
+    """Representation of the `object_payment_method` relation."""
+
+    object_id: Optional[str]
+    payment_code: str
+    payment_name: Optional[str] = None
+
+    def to_supabase(self, *, payment_method_id: Optional[str]) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"object_id": self.object_id}
+        if payment_method_id:
+            payload["payment_method_id"] = payment_method_id
+        extra: Dict[str, Any] = {}
+        if not payment_method_id:
+            extra["payment_code"] = self.payment_code
+        if self.payment_name:
+            extra["payment_name"] = self.payment_name
+        if extra:
+            payload["extra"] = extra
+        return payload
+
+
+class PaymentMethodTransformation(BaseModel):
+    payment_methods: List[PaymentMethodRecord]
+
+
+class EnvironmentTagRecord(BaseModel):
+    """Representation of the `object_environment_tag` relation."""
+
+    object_id: Optional[str]
+    environment_code: str
+    environment_name: Optional[str] = None
+
+    def to_supabase(self, *, environment_tag_id: Optional[str]) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"object_id": self.object_id}
+        if environment_tag_id:
+            payload["environment_tag_id"] = environment_tag_id
+        extra: Dict[str, Any] = {}
+        if not environment_tag_id:
+            extra["environment_code"] = self.environment_code
+        if self.environment_name:
+            extra["environment_name"] = self.environment_name
+        if extra:
+            payload["extra"] = extra
+        return payload
+
+
+class EnvironmentTagTransformation(BaseModel):
+    environment_tags: List[EnvironmentTagRecord]
+
+
+class PetPolicyRecord(BaseModel):
+    """Representation of the `object_pet_policy` table."""
+
+    object_id: Optional[str]
+    accepted: Optional[bool]
+    conditions: Optional[str] = None
+
+    def to_supabase(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"object_id": self.object_id}
+        if self.accepted is not None:
+            payload["accepted"] = self.accepted
+        if self.conditions:
+            payload["conditions"] = self.conditions
+        return payload
+
+
+class PetPolicyTransformation(BaseModel):
+    pet_policy: Optional[PetPolicyRecord] = None
 
 
 class MediaRecord(BaseModel):

--- a/migration-tool/migration_tool/supabase_client.py
+++ b/migration-tool/migration_tool/supabase_client.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+import re
+import unicodedata
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 from supabase import Client, create_client
 
@@ -55,6 +57,10 @@ class SupabaseService:
             query = self._client.table(table).upsert(data)
             if on_conflict:
                 query = query.on_conflict(on_conflict)
+            # Ensure we get the representation of the affected rows so agents can
+            # extract generated identifiers without issuing a follow-up query.
+            if hasattr(query, "select"):
+                query = query.select("*")
             response = query.execute()
             return getattr(response, "model_dump", lambda: response.__dict__)()
 
@@ -75,11 +81,12 @@ class SupabaseService:
     async def lookup(self, table: str, *, code: str, code_field: str = "code") -> Optional[str]:
         """Resolve a reference code to its primary key."""
 
-        cache_key = (table, code_field, code)
+        normalized_code = self.normalize_code(code) if code_field == "code" else str(code)
+        cache_key = (table, code_field, normalized_code)
         if cache_key in self._lookup_cache:
             return self._lookup_cache[cache_key]
 
-        if not code:
+        if not normalized_code:
             self._lookup_cache[cache_key] = None
             return None
 
@@ -95,7 +102,7 @@ class SupabaseService:
             response = (
                 self._client.table(table)
                 .select("id")
-                .eq(code_field, code)
+                .eq(code_field, normalized_code)
                 .limit(1)
                 .execute()
             )
@@ -116,9 +123,299 @@ class SupabaseService:
         self._lookup_cache[cache_key] = identifier
         self.telemetry.record(
             "supabase.lookup",
-            {"table": table, "code": code, "code_field": code_field, "resolved_id": identifier},
+            {
+                "table": table,
+                "code": normalized_code,
+                "code_field": code_field,
+                "resolved_id": identifier,
+            },
         )
         return identifier
+
+    def normalize_code(self, code: str) -> str:
+        """Normalise a label/code into the DLL slug format."""
+
+        text = unicodedata.normalize("NFKD", str(code))
+        text = "".join(ch for ch in text if not unicodedata.combining(ch))
+        text = re.sub(r"[^a-z0-9]+", "_", text.lower())
+        return text.strip("_")
+
+    async def ensure_code(
+        self,
+        *,
+        domain: str,
+        code: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Ensure a ref_code entry exists and return its identifier."""
+
+        normalized_code = self.normalize_code(code)
+        existing = await self.lookup(f"ref_code_{domain}", code=normalized_code)
+        if existing:
+            return existing
+
+        payload = {
+            "domain": domain,
+            "code": normalized_code,
+            "name": name or code.title(),
+        }
+        if description:
+            payload["description"] = description
+        if metadata:
+            payload["metadata"] = metadata
+
+        await self.upsert("ref_code", payload, on_conflict="domain,code")
+        cache_key = (f"ref_code_{domain}", "code", normalized_code)
+        self._lookup_cache.pop(cache_key, None)
+        return await self.lookup(f"ref_code_{domain}", code=normalized_code)
+
+    async def ensure_amenity(
+        self,
+        *,
+        code: str,
+        name: Optional[str],
+        family_code: Optional[str] = None,
+    ) -> Optional[str]:
+        """Ensure an amenity exists in the reference table."""
+
+        normalized_code = self.normalize_code(code)
+        existing = await self.lookup("ref_amenity", code=normalized_code)
+        if existing:
+            return existing
+
+        family_slug = self.normalize_code(family_code) if family_code else "services"
+        family_id = await self.ensure_code(domain="amenity_family", code=family_slug, name=family_code or "Services")
+
+        payload = {
+            "code": normalized_code,
+            "name": name or normalized_code.replace("_", " ").title(),
+            "family_id": family_id,
+            "scope": "object",
+        }
+
+        response = await self.upsert("ref_amenity", payload, on_conflict="code")
+        data = response.get("data") if isinstance(response, dict) else None
+        if isinstance(data, list) and data:
+            identifier = data[0].get("id")
+            return str(identifier) if identifier else await self.lookup("ref_amenity", code=normalized_code)
+        cache_key = ("ref_amenity", "code", normalized_code)
+        self._lookup_cache.pop(cache_key, None)
+        return await self.lookup("ref_amenity", code=normalized_code)
+
+    async def ensure_language(self, *, code: str, name: Optional[str] = None) -> Optional[str]:
+        """Ensure a language exists in the reference table."""
+
+        normalized_code = str(code).strip().lower()
+        if not normalized_code:
+            return None
+        existing = await self.lookup("ref_language", code=normalized_code)
+        if existing:
+            return existing
+
+        payload = {
+            "code": normalized_code,
+            "name": name or normalized_code.upper(),
+        }
+
+        await self.upsert("ref_language", payload, on_conflict="code")
+        cache_key = ("ref_language", "code", normalized_code)
+        self._lookup_cache.pop(cache_key, None)
+        return await self.lookup("ref_language", code=normalized_code)
+
+    async def find_existing_object(
+        self,
+        *,
+        name: Optional[str],
+        latitude: Optional[float],
+        longitude: Optional[float],
+        category: Optional[str],
+        subcategory: Optional[str],
+    ) -> Optional[Dict[str, Any]]:
+        """Find an existing object matching the provided identity features."""
+
+        if not self._client:
+            self.telemetry.record(
+                "supabase.dedup.skipped",
+                {
+                    "reason": "no credentials",
+                    "name": name,
+                    "latitude": latitude,
+                    "longitude": longitude,
+                    "category": category,
+                    "subcategory": subcategory,
+                },
+            )
+            return None
+
+        def _extract_data(response: Any) -> List[Dict[str, Any]]:
+            if hasattr(response, "data"):
+                return getattr(response, "data") or []  # type: ignore[return-value]
+            if isinstance(response, dict):
+                data = response.get("data")
+                if isinstance(data, list):
+                    return data
+            return getattr(response, "__dict__", {}).get("data", []) or []
+
+        def _matches_category(candidate: Dict[str, Any]) -> bool:
+            extra = candidate.get("extra") or {}
+            candidate_category = (extra.get("category") or "").lower() if isinstance(extra, dict) else None
+            candidate_subcategory = (extra.get("subcategory") or "").lower() if isinstance(extra, dict) else None
+
+            def _normalize(value: Optional[str]) -> Optional[str]:
+                return value.lower() if isinstance(value, str) else None
+
+            category_match = not category or not candidate_category or _normalize(category) == candidate_category
+            subcategory_match = not subcategory or not candidate_subcategory or _normalize(subcategory) == candidate_subcategory
+            return category_match and subcategory_match
+
+        def _fetch_objects(object_ids: Iterable[str]) -> List[Dict[str, Any]]:
+            unique_ids: List[str] = [oid for oid in dict.fromkeys(object_ids) if oid]
+            if not unique_ids:
+                return []
+            response = (
+                self._client.table("object")
+                .select("id,name,object_type,extra")
+                .in_("id", unique_ids)
+                .execute()
+            )
+            return _extract_data(response)
+
+        def _execute() -> Optional[Dict[str, Any]]:
+            coordinate_candidates: List[Dict[str, Any]] = []
+            if latitude is not None and longitude is not None:
+                location_response = (
+                    self._client.table("object_location")
+                    .select("object_id,latitude,longitude")
+                    .eq("latitude", latitude)
+                    .eq("longitude", longitude)
+                    .execute()
+                )
+                coordinate_ids = [row.get("object_id") for row in _extract_data(location_response) if isinstance(row, dict)]
+                coordinate_candidates = _fetch_objects(oid for oid in coordinate_ids if oid)
+
+            for candidate in coordinate_candidates:
+                if not isinstance(candidate, dict):
+                    continue
+                if _matches_category(candidate):
+                    candidate["match_reason"] = "coordinates"
+                    return candidate
+
+            name_candidates: List[Dict[str, Any]] = []
+            if name:
+                query = self._client.table("object").select("id,name,object_type,extra")
+                ilike_method = getattr(query, "ilike", None)
+                if callable(ilike_method):
+                    query = ilike_method("name", name)
+                else:
+                    query = query.eq("name", name)
+                name_response = query.execute()
+                name_candidates = _extract_data(name_response)
+
+            for candidate in name_candidates:
+                if not isinstance(candidate, dict):
+                    continue
+                if _matches_category(candidate):
+                    candidate["match_reason"] = "name"
+                    return candidate
+            return None
+
+        try:
+            match = await asyncio.to_thread(_execute)
+            self.telemetry.record(
+                "supabase.dedup.lookup",
+                {
+                    "name": name,
+                    "latitude": latitude,
+                    "longitude": longitude,
+                    "category": category,
+                    "subcategory": subcategory,
+                    "match": match,
+                },
+            )
+            return match
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self.telemetry.record(
+                "supabase.dedup.error",
+                {
+                    "name": name,
+                    "latitude": latitude,
+                    "longitude": longitude,
+                    "category": category,
+                    "subcategory": subcategory,
+                    "error": str(exc),
+                },
+            )
+            return None
+
+    async def record_external_ids(
+        self,
+        *,
+        object_id: str,
+        organization_id: str,
+        external_ids: Sequence[str],
+    ) -> List[Dict[str, Any]]:
+        """Persist external identifiers linked to an object."""
+
+        normalized_ids = [str(identifier) for identifier in dict.fromkeys(external_ids) if identifier]
+        if not normalized_ids or not object_id or not organization_id:
+            return []
+
+        payload = [
+            {
+                "object_id": object_id,
+                "organization_object_id": organization_id,
+                "external_id": identifier,
+            }
+            for identifier in normalized_ids
+        ]
+
+        if not self._client:
+            self.telemetry.record(
+                "supabase.external_ids.skipped",
+                {
+                    "reason": "no credentials",
+                    "object_id": object_id,
+                    "organization_id": organization_id,
+                    "external_ids": normalized_ids,
+                },
+            )
+            return []
+
+        def _execute() -> Dict[str, Any]:
+            response = (
+                self._client.table("object_external_id")
+                .upsert(payload)
+                .on_conflict("organization_object_id,external_id")
+                .execute()
+            )
+            return getattr(response, "model_dump", lambda: response.__dict__)()
+
+        try:
+            result = await asyncio.to_thread(_execute)
+            self.telemetry.record(
+                "supabase.external_ids.upsert",
+                {
+                    "object_id": object_id,
+                    "organization_id": organization_id,
+                    "external_ids": normalized_ids,
+                    "response": result,
+                },
+            )
+            data = result.get("data") if isinstance(result, dict) else None
+            return data if isinstance(data, list) else []
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self.telemetry.record(
+                "supabase.external_ids.error",
+                {
+                    "object_id": object_id,
+                    "organization_id": organization_id,
+                    "external_ids": normalized_ids,
+                    "error": str(exc),
+                },
+            )
+            return []
 
 
 __all__ = ["SupabaseService"]

--- a/migration-tool/tests/test_ai_providers_schedule.py
+++ b/migration-tool/tests/test_ai_providers_schedule.py
@@ -65,7 +65,7 @@ async def test_provider_agent_ai_transformation() -> None:
             }
         ]
     }
-    context = AgentContext(coordinator_id="test", source_payload=payload)
+    context = AgentContext(coordinator_id="test", source_payload=payload, object_id="reccZJ9INTTb7Mxtg")
 
     # Test AI transformation directly
     transformation = await llm.transform_fragment(
@@ -79,29 +79,32 @@ async def test_provider_agent_ai_transformation() -> None:
     
     # Check first provider
     provider1 = transformation.providers[0]
-    assert provider1.provider_id == "AdJe0544bj"
+    assert provider1.provider_id is None
     assert provider1.last_name == "Adenor"
     assert provider1.first_name == "Jean-Luc"
     assert provider1.email == "loc.amarysreunion@orange.fr"
     assert provider1.phone == "0692600544"
     assert provider1.newsletter is True
     assert provider1.address1 == "Chemin de la Concession les Bas"
-    assert provider1.postcode == 97418
+    assert provider1.postcode == "97418"
     assert provider1.city == "La Plaine des Cafres"
-    
+    assert provider1.legacy_ids == ["AdJe0544bj"]
+
     # Check second provider
     provider2 = transformation.providers[1]
-    assert provider2.provider_id == "AdMa0544yT"
+    assert provider2.provider_id is None
     assert provider2.last_name == "Adenor"
     assert provider2.first_name == "Maryse"
     assert provider2.function == "Gérant"
     assert provider2.date_of_birth == "01/04/1972"
     assert provider2.revenue == "Principale"
+    assert provider2.legacy_ids == ["AdMa0544yT"]
 
     # Test agent handle method
     result = await agent.handle(payload, context)
     assert result["status"] == "ok"
-    assert result["operation"] == "no_data"  # Because Supabase is not available in test
+    assert result["operation"] == "upsert"
+    assert result["linked_providers"] == 2
 
 
 @pytest.mark.anyio
@@ -133,7 +136,7 @@ async def test_schedule_agent_ai_transformation() -> None:
             }
         ]
     }
-    context = AgentContext(coordinator_id="test", source_payload=payload)
+    context = AgentContext(coordinator_id="test", source_payload=payload, object_id="reccZJ9INTTb7Mxtg")
 
     # Test AI transformation directly
     transformation = await llm.transform_fragment(
@@ -150,15 +153,16 @@ async def test_schedule_agent_ai_transformation() -> None:
     assert schedule.days == ["wednesday", "thursday", "friday", "saturday", "sunday"]
     assert schedule.am_start == "09:30"
     assert schedule.am_finish == "15:00"
-    assert schedule.pm_start == ""
-    assert schedule.pm_finish == ""
+    assert schedule.pm_start in {None, ""}
+    assert schedule.pm_finish in {None, ""}
     assert schedule.reservation_required is True
     assert schedule.schedule_type == "regular"
 
     # Test agent handle method
     result = await agent.handle(payload, context)
     assert result["status"] == "ok"
-    assert result["operation"] == "no_data"  # Because Supabase is not available in test
+    assert result["operation"] == "upsert"
+    assert result["created_schedules"] == 1
 
 
 def test_rule_based_llm_providers_transformation() -> None:
@@ -188,13 +192,14 @@ def test_rule_based_llm_providers_transformation() -> None:
     
     assert len(transformation.providers) == 1
     provider = transformation.providers[0]
-    assert provider.provider_id == "test_provider"
+    assert provider.provider_id is None
     assert provider.last_name == "Dupont"
     assert provider.first_name == "Jean"
     assert provider.email == "jean.dupont@test.com"
     assert provider.phone == "0123456789"
     assert provider.function == "Manager"
     assert provider.newsletter is True
+    assert provider.legacy_ids == ["test_provider"]
 
 
 def test_rule_based_llm_schedule_transformation() -> None:

--- a/migration-tool/tests/test_coordinator_identity_flow.py
+++ b/migration-tool/tests/test_coordinator_identity_flow.py
@@ -1,0 +1,111 @@
+import pytest
+
+from migration_tool.agents.base import Agent
+from migration_tool.agents.coordinator import Coordinator
+from migration_tool.schemas import FieldRoutingDecision, RawEstablishmentPayload
+from migration_tool.telemetry import EventLog
+from migration_tool.webhook import WebhookNotifier
+
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+
+class StubRouter:
+    def __init__(self, sections: dict[str, dict[str, object]]) -> None:
+        self._sections = sections
+
+    async def route(self, *, payload, agent_descriptors):  # pragma: no cover - simple shim
+        return FieldRoutingDecision(
+            assignments=[],
+            leftovers={},
+            sections={name: dict(section) for name, section in self._sections.items()},
+        )
+
+
+class IdentityStub(Agent):
+    name = "identity"
+    description = "stub"
+
+    def __init__(self, generated_id: str = "OBJ-IDENTITY") -> None:
+        super().__init__()
+        self.generated_id = generated_id
+        self.calls: list[dict[str, object]] = []
+        self.expected_fields = ["establishment_name"]
+
+    async def handle(self, payload, context):
+        self.calls.append(payload)
+        context.object_id = payload.get("establishment_id") or self.generated_id
+        return {"object_id": context.object_id}
+
+
+class RecordingStub(Agent):
+    def __init__(self, name: str) -> None:
+        super().__init__()
+        self.name = name
+        self.description = name
+        self.expected_fields = []
+        self.calls: list[dict[str, object]] = []
+        self.object_ids: list[object] = []
+
+    async def handle(self, payload, context):
+        self.calls.append(payload)
+        self.object_ids.append(context.object_id)
+        return {"status": "ok", "agent": self.name}
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_identity_id_propagation_when_router_omits_section():
+    sample_payload = RawEstablishmentPayload.model_validate(
+        [
+            {
+                "dataProvidingOrg": "ORG-001",
+                "data": [
+                    {
+                        "Nom_OTI": "Le Relais Commerson",
+                        "Groupe catégorie": "Restauration",
+                        "Nom catégorie": "Restaurant",
+                        "Nom sous catégorie": "Restaurant",
+                        "Coordonnées GPS": "-21.204197, 55.577417",
+                    }
+                ],
+            }
+        ]
+    )
+
+    identity_agent = IdentityStub()
+    contact_agent = RecordingStub("contact")
+    router = StubRouter({"contact": {"phone": ["0262275287"]}})
+    telemetry = EventLog()
+    webhook = WebhookNotifier(url=None, telemetry=telemetry)
+
+    coordinator = Coordinator(
+        identity_agent=identity_agent,
+        location_agent=RecordingStub("location"),
+        contact_agent=contact_agent,
+        amenities_agent=RecordingStub("amenities"),
+        language_agent=RecordingStub("languages"),
+        payment_agent=RecordingStub("payments"),
+        environment_agent=RecordingStub("environment"),
+        pet_policy_agent=RecordingStub("pet_policy"),
+        media_agent=RecordingStub("media"),
+        provider_agent=RecordingStub("providers"),
+        schedule_agent=RecordingStub("schedule"),
+        webhook=webhook,
+        telemetry=telemetry,
+        router=router,
+    )
+
+    fragments, leftovers = await coordinator.handle(sample_payload)
+
+    assert leftovers == {}
+    assert any(fragment.agent == "identity" for fragment in fragments)
+    assert contact_agent.object_ids[0] == identity_agent.generated_id
+    assert contact_agent.calls[0]["establishment_id"] == identity_agent.generated_id
+    assert identity_agent.calls[0]["establishment_name"] == sample_payload.establishment_name
+    assert identity_agent.calls[0]["legacy_ids"] == []
+

--- a/migration-tool/tests/test_identity_agent.py
+++ b/migration-tool/tests/test_identity_agent.py
@@ -1,0 +1,123 @@
+import pytest
+
+from migration_tool.agents.identity import IdentityAgent
+from migration_tool.schemas import AgentContext, IdentityRecord
+from migration_tool.telemetry import EventLog
+from migration_tool.ai import LLMClient
+
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+
+class DummyLLM(LLMClient):
+    name = "dummy"
+
+    async def classify_fields(self, *, payload, agent_descriptors):  # pragma: no cover - unused in tests
+        raise NotImplementedError
+
+    async def transform_fragment(self, *, agent_name, payload, response_model):
+        return IdentityRecord(
+            object_id=payload.get("establishment_id"),
+            object_type="HOT",
+            name=payload.get("establishment_name", "Unknown"),
+            description=payload.get("description"),
+            category_code="res",
+            subcategory_code="bar",
+            legacy_ids=payload.get("legacy_ids", []),
+            source_extra={k: v for k, v in payload.items() if k not in {"establishment_name", "legacy_ids"}},
+        )
+
+
+class StubSupabase:
+    def __init__(self) -> None:
+        self.upserts = []
+        self.find_kwargs = None
+        self.find_result = None
+        self.external_calls = []
+        self.generated_id = "GEN-001"
+
+    async def upsert(self, table, data, on_conflict=None):
+        self.upserts.append((table, data, on_conflict))
+        identifier = data.get("id") or self.generated_id
+        return {"data": [{"id": identifier}]}
+
+    async def find_existing_object(self, **kwargs):
+        self.find_kwargs = kwargs
+        return self.find_result
+
+    async def record_external_ids(self, *, object_id, organization_id, external_ids):
+        call = {
+            "object_id": object_id,
+            "organization_id": organization_id,
+            "external_ids": list(external_ids),
+        }
+        self.external_calls.append(call)
+        return [{"object_id": object_id, "external_id": ext} for ext in external_ids]
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def test_identity_agent_reuses_existing_object():
+    supabase = StubSupabase()
+    supabase.find_result = {"id": "OBJ-123", "match_reason": "coordinates"}
+    agent = IdentityAgent(supabase=supabase, telemetry=EventLog(), llm=DummyLLM())
+
+    payload = {
+        "establishment_name": "Test Establishment",
+        "legacy_ids": ["LEG-001"],
+        "description": "Sample",
+    }
+    context = AgentContext(
+        coordinator_id="coord",
+        source_payload={
+            "latitude": 12.34,
+            "longitude": 56.78,
+            "provider_id": "ORG-777",
+        },
+    )
+
+    result = await agent.handle(payload, context)
+
+    assert result["object_id"] == "OBJ-123"
+    assert result["duplicate_of"] == "OBJ-123"
+    assert context.object_id == "OBJ-123"
+    assert context.duplicate_of == "OBJ-123"
+    assert supabase.find_kwargs == {
+        "name": "Test Establishment",
+        "latitude": 12.34,
+        "longitude": 56.78,
+        "category": "res",
+        "subcategory": "bar",
+    }
+    assert supabase.upserts[0][1]["id"] == "OBJ-123"
+    assert supabase.external_calls == [
+        {"object_id": "OBJ-123", "organization_id": "ORG-777", "external_ids": ["LEG-001"]}
+    ]
+
+
+async def test_identity_agent_inserts_new_object_when_no_match():
+    supabase = StubSupabase()
+    supabase.generated_id = "OBJ-999"
+    agent = IdentityAgent(supabase=supabase, telemetry=EventLog(), llm=DummyLLM())
+
+    payload = {
+        "establishment_name": "Another Establishment",
+        "legacy_ids": ["LEG-XYZ"],
+    }
+    context = AgentContext(
+        coordinator_id="coord",
+        source_payload={"provider_organization_id": "ORG-123"},
+    )
+
+    result = await agent.handle(payload, context)
+
+    assert result["object_id"] == "OBJ-999"
+    assert result["duplicate_of"] is None
+    assert context.object_id == "OBJ-999"
+    assert context.duplicate_of is None
+    assert supabase.external_calls == [
+        {"object_id": "OBJ-999", "organization_id": "ORG-123", "external_ids": ["LEG-XYZ"]}
+    ]

--- a/migration-tool/tests/test_payload_normalisation.py
+++ b/migration-tool/tests/test_payload_normalisation.py
@@ -1,0 +1,208 @@
+"""Tests covering normalisation of legacy payload envelopes."""
+
+from __future__ import annotations
+
+import pytest
+
+import pytest
+
+from migration_tool.schemas import RawEstablishmentPayload
+
+
+def _sample_payload() -> list[dict[str, object]]:
+    return [
+        {
+            "dataProvidingOrg": "ORGRUN000001",
+            "data": [
+                {
+                    "Nom_OTI": "Le Relais Commerson",
+                    "Groupe catégorie": "Restauration",
+                    "Nom catégorie": "Restaurant",
+                    "Nom sous catégorie": "Restaurant",
+                    "Numéro": "37",
+                    "rue": "rue Boisjoly Potier",
+                    "Code Postal": 97418,
+                    "ville": "Le Tampon",
+                    "Localisations": "Village,Milieu rural",
+                    "Coordonnées GPS": "-21.204197, 55.577417",
+                    "E-Mail": "info@example.com",
+                    "Contact principale": "0262275287",
+                    "Autre téléphone": "0692600544",
+                    "Web": "https://example.com",
+                    "Prestations sur place": "parking, wifi",
+                    "Mode de paiement": "Carte Bancaire,Espèces",
+                    "Langues": "français,anglais",
+                    "Descriptif OTI": "Description",
+                    "Accroche OTI": "Summary",
+                    "Status": "Ouvert",
+                    "Handicap": True,
+                    "Animaux": False,
+                    "id OTI": "ABC123",
+                },
+                {
+                    "data": [
+                        {
+                            "Presta ID": "P001",
+                            "Nom": "Adenor",
+                            "Prénom": "Jean-Luc",
+                            "Email": "jean@example.com",
+                        }
+                    ]
+                },
+                {
+                    "data": [
+                        {
+                            "Horaires_id": "H001",
+                            "jours": "Lundi , Mardi",
+                            "AM_Start": "09:00",
+                            "AM_Finish": "17:00",
+                        }
+                    ]
+                },
+                {
+                    "data": [
+                        {
+                            "id_multimedia": "M001",
+                            "lien": "https://example.com/photo.jpg",
+                            "type": "image/jpeg",
+                            "description": "Exterior",
+                            "principale": True,
+                        }
+                    ]
+                },
+                {
+                    "data": [
+                        {
+                            "Type_R_S": "facebook",
+                            "URL": "https://facebook.com/relais",
+                        }
+                    ]
+                },
+            ],
+        }
+    ]
+
+
+def test_raw_payload_is_normalised() -> None:
+    payload = RawEstablishmentPayload.model_validate(_sample_payload())
+
+    assert payload.establishment_name == "Le Relais Commerson"
+    assert payload.establishment_category == "Restaurant"
+    assert payload.establishment_subcategory == "Restaurant"
+    assert payload.source_organization_id == "ORGRUN000001"
+    assert "ABC123" in payload.legacy_ids
+
+    data = payload.data
+    assert data["address_line1"].startswith("37")
+    assert data["city"] == "Le Tampon"
+    assert pytest.approx(data["latitude"], rel=1e-3) == -21.204
+    assert "parking" in data["amenities"]
+    assert any("village" in tag.lower() for tag in data["environment_tags"])
+    assert any("carte" in method.lower() for method in data["payment_methods"])
+    assert any(lang.lower().startswith("fr") for lang in data["languages"])
+    assert data["pets_allowed"] is False
+    assert any(media_item["url"].startswith("https://example.com") for media_item in data["media"])
+    assert data["providers"][0]["Presta ID"] == "P001"
+    assert data["schedule"][0]["Horaires_id"] == "H001"
+    assert data["socials"][0]["network"] == "facebook"
+
+
+def test_payload_from_json_string() -> None:
+    json_payload = """
+    [
+      {
+        "name": "Le Relais Commerson",
+        "category": "Restaurant",
+        "subcategory": "Restaurant",
+        "dataProvidingOrg": "ORGRUN000001",
+        "data": {
+          "address_line1": "37 rue Boisjoly Potier",
+          "city": "Le Tampon",
+          "latitude": -21.204197,
+          "longitude": 55.577417
+        }
+      }
+    ]
+    """
+
+    payload = RawEstablishmentPayload.model_validate(json_payload)
+
+    assert payload.establishment_name == "Le Relais Commerson"
+    assert payload.establishment_category == "Restaurant"
+    assert payload.data["city"] == "Le Tampon"
+
+
+def test_payload_from_xml_string() -> None:
+    xml_payload = """
+    <establishment>
+        <name>Le Relais Commerson</name>
+        <category>Restaurant</category>
+        <subcategory>Restaurant</subcategory>
+        <dataProvidingOrg>ORGRUN000001</dataProvidingOrg>
+        <data>
+            <address_line1>37 rue Boisjoly Potier</address_line1>
+            <city>Le Tampon</city>
+            <latitude>-21.204197</latitude>
+            <longitude>55.577417</longitude>
+        </data>
+    </establishment>
+    """
+
+    payload = RawEstablishmentPayload.model_validate(xml_payload)
+
+    assert payload.establishment_name == "Le Relais Commerson"
+    assert payload.establishment_category == "Restaurant"
+    assert pytest.approx(-21.204197, rel=1e-3) == payload.data["latitude"]
+    assert payload.data["raw_xml_tag"] == "establishment"
+
+
+def test_payload_from_plain_text() -> None:
+    text_payload = """
+    Nom_OTI: Le Relais Commerson
+    Groupe catégorie: Restauration
+    Nom catégorie: Restaurant
+    Nom sous catégorie: Restaurant
+    dataProvidingOrg: ORGRUN000001
+    Numéro: 37
+    rue: rue Boisjoly Potier
+    ville: Le Tampon
+    Coordonnées GPS: -21.204197, 55.577417
+    E-Mail: info@example.com
+    Contact principale: 0262275287
+    """
+
+    payload = RawEstablishmentPayload.model_validate(text_payload)
+
+    assert payload.establishment_name == "Le Relais Commerson"
+    assert payload.establishment_category in {"Restauration", "Restaurant"}
+    assert payload.data["city"] == "Le Tampon"
+    phone_field = payload.data["phone"]
+    if isinstance(phone_field, list):
+        assert "0262275287" in phone_field
+    else:
+        assert "0262275287" in str(phone_field)
+
+
+def test_payload_with_body_envelope() -> None:
+    payload = {
+        "body": {
+            "SubmitingOrgId": "ORG-123",
+            "data": {
+                "data": [
+                    {
+                        "Nom_OTI": "Le Relais Commerson",
+                        "Nom catégorie": "Restaurant",
+                        "Coordonnées GPS": "-21.204197, 55.577417",
+                        "E-Mail": "info@example.com",
+                    }
+                ]
+            },
+        }
+    }
+
+    normalised = RawEstablishmentPayload.model_validate(payload)
+
+    assert normalised.establishment_name == "Le Relais Commerson"
+    assert normalised.establishment_category == "Restaurant"
+    assert normalised.source_organization_id == "ORG-123"
+    assert normalised.data["email"] == "info@example.com"

--- a/migration-tool/tests/test_providers_schedule.py
+++ b/migration-tool/tests/test_providers_schedule.py
@@ -1,5 +1,8 @@
+import types
+
 import pytest
 
+from migration_tool.ai import RuleBasedLLM
 from migration_tool.agents.providers import ProviderAgent
 from migration_tool.agents.schedule import ScheduleAgent
 from migration_tool.schemas import AgentContext
@@ -13,145 +16,129 @@ def anyio_backend() -> str:
 
 
 @pytest.mark.anyio
-async def test_provider_agent_extraction() -> None:
+async def test_provider_agent_processes_nested_payload() -> None:
     telemetry = EventLog(retention=10)
     supabase = SupabaseService(url=None, key=None, telemetry=telemetry)
-    agent = ProviderAgent(supabase, telemetry)
+    llm = RuleBasedLLM()
+    agent = ProviderAgent(supabase, telemetry, llm)
 
-    # Test payload with nested provider data (like your real data)
     payload = {
         "establishment_id": "reccZJ9INTTb7Mxtg",
         "prestataires": [
             {
                 "data": [
                     {
-                        "row_number": 30,
                         "Presta ID": "AdJe0544bj",
                         "Nom": "Adenor",
                         "Prénom": "Jean-Luc",
-                        "Genre": "Mr",
-                        "Email": "loc.amarysreunion@orange.fr",
+                        "Email": "jean@example.com",
                         "Numéro de telephone": "0692600544",
-                        "Fonction": "",
-                        "Newsletter": True,
-                        "Nombre d'establissements": 3,
-                        "Numéro": 37,
-                        "rue": "Chemin de la Concession les Bas",
-                        "Code Postal": 97418,
-                        "ville": "La Plaine des Cafres",
-                        "Lieux-dits": "",
                     },
                     {
-                        "row_number": 31,
                         "Presta ID": "AdMa0544yT",
                         "Nom": "Adenor",
                         "Prénom": "Maryse",
-                        "Genre": "Mme",
-                        "Email": "lerelaiscommerson97418@orange.fr",
-                        "Numéro de telephone": "0692600544",
-                        "Fonction": "Gérant",
-                        "Newsletter": True,
-                        "Nombre d'establissements": 0,
-                        "Numéro": "37",
-                        "rue": "rue Boisjoly Potier",
-                        "Code Postal": 97418,
-                        "ville": "La Plaine des Cafres",
-                        "Lieux-dits": "",
-                        "DOB": "01/04/1972",
-                        "Revenus": "Principale",
-                    }
+                        "Email": "maryse@example.com",
+                        "Numéro de telephone": "0692600545",
+                    },
                 ]
             }
-        ]
+        ],
     }
-    context = AgentContext(coordinator_id="test", source_payload=payload)
+    context = AgentContext(coordinator_id="test", source_payload=payload, object_id="reccZJ9INTTb7Mxtg")
 
     result = await agent.handle(payload, context)
 
     assert result["status"] == "ok"
-    assert result["operation"] == "no_data"  # Because Supabase is not available in test
-    assert result["message"] == "No valid provider data found"
+    assert result["table"] == "object_provider"
+    assert result["linked_providers"] == 2
+
+    jean_identifier = context.provider_registry.get("jean@example.com")
+    maryse_identifier = context.provider_registry.get("maryse@example.com")
+
+    assert jean_identifier is not None
+    assert maryse_identifier is not None
+    assert jean_identifier == context.provider_registry.get("AdJe0544bj")
+    assert maryse_identifier == context.provider_registry.get("AdMa0544yT")
 
 
 @pytest.mark.anyio
-async def test_schedule_agent_extraction() -> None:
+async def test_provider_agent_uses_returned_identifier() -> None:
     telemetry = EventLog(retention=10)
     supabase = SupabaseService(url=None, key=None, telemetry=telemetry)
-    agent = ScheduleAgent(supabase, telemetry)
 
-    # Test payload with nested schedule data (like your real data)
+    async def fake_upsert(self, table, data, on_conflict=None):
+        if table == "provider":
+            assert "id" not in data
+            return {"data": [{"id": "prov-123", "email": data.get("email")}]}  # type: ignore[return-value]
+        if table == "object_provider":
+            assert data.get("provider_id") == "prov-123"
+            return {"data": [data]}  # type: ignore[return-value]
+        return {"data": []}  # type: ignore[return-value]
+
+    supabase.upsert = types.MethodType(fake_upsert, supabase)  # type: ignore[assignment]
+
+    llm = RuleBasedLLM()
+    agent = ProviderAgent(supabase, telemetry, llm)
+
+    payload = {
+        "establishment_id": "obj-1",
+        "providers": [
+            {
+                "Nom": "Doe",
+                "Prénom": "Jane",
+                "Email": "jane@example.com",
+                "Numéro de telephone": "0123456789",
+                "Presta ID": "legacy-123",
+            }
+        ],
+    }
+    context = AgentContext(coordinator_id="test", source_payload=payload, object_id="obj-1")
+
+    result = await agent.handle(payload, context)
+
+    assert result["status"] == "ok"
+    assert result["created_providers"] == ["prov-123"]
+    assert context.provider_registry["jane@example.com"] == "prov-123"
+    assert context.provider_registry["legacy-123"] == "prov-123"
+
+
+@pytest.mark.anyio
+async def test_schedule_agent_processes_nested_payload() -> None:
+    telemetry = EventLog(retention=10)
+    supabase = SupabaseService(url=None, key=None, telemetry=telemetry)
+    llm = RuleBasedLLM()
+    agent = ScheduleAgent(supabase, telemetry, llm)
+
     payload = {
         "establishment_id": "reccZJ9INTTb7Mxtg",
         "horaires": [
             {
                 "data": [
                     {
-                        "row_number": 500,
                         "Horaires_id": "3508de48",
-                        "formulaire": "reccZJ9INTTb7Mxtg",
                         "jours": "Mercredi , Jeudi , Vendredi , Samedi , Dimanche",
                         "AM_Start": "09:30",
                         "AM_Finish": "15:00",
-                        "PM_Start": "",
-                        "PM_Finish": "",
                         "Révervation": True,
                     }
                 ]
             }
-        ]
+        ],
     }
-    context = AgentContext(coordinator_id="test", source_payload=payload)
+    context = AgentContext(coordinator_id="test", source_payload=payload, object_id="reccZJ9INTTb7Mxtg")
 
     result = await agent.handle(payload, context)
 
     assert result["status"] == "ok"
-    assert result["operation"] == "no_data"  # Because Supabase is not available in test
-    assert result["message"] == "No valid schedule data found"
+    assert result["operation"] == "upsert"
+    assert result["created_schedules"] == 1
 
 
-def test_schedule_day_parsing() -> None:
-    telemetry = EventLog(retention=10)
-    supabase = SupabaseService(url=None, key=None, telemetry=telemetry)
-    agent = ScheduleAgent(supabase, telemetry)
-
-    # Test French day parsing
+def test_rule_based_schedule_day_parsing() -> None:
+    llm = RuleBasedLLM()
     jours_str = "Mercredi , Jeudi , Vendredi , Samedi , Dimanche"
-    days = agent._parse_days(jours_str)
-    
+    days = llm._parse_schedule_days(jours_str)
+
     expected_days = ["wednesday", "thursday", "friday", "saturday", "sunday"]
     assert days == expected_days
-
-
-def test_provider_record_extraction() -> None:
-    telemetry = EventLog(retention=10)
-    supabase = SupabaseService(url=None, key=None, telemetry=telemetry)
-    agent = ProviderAgent(supabase, telemetry)
-
-    provider_data = {
-        "Presta ID": "AdJe0544bj",
-        "Nom": "Adenor",
-        "Prénom": "Jean-Luc",
-        "Genre": "Mr",
-        "Email": "loc.amarysreunion@orange.fr",
-        "Numéro de telephone": "0692600544",
-        "Fonction": "Gérant",
-        "Newsletter": True,
-        "Numéro": 37,
-        "rue": "Chemin de la Concession les Bas",
-        "Code Postal": 97418,
-        "ville": "La Plaine des Cafres",
-    }
-
-    provider_record = agent._extract_provider_record(provider_data, "test_establishment")
-    
-    assert provider_record is not None
-    assert provider_record.provider_id == "AdJe0544bj"
-    assert provider_record.last_name == "Adenor"
-    assert provider_record.first_name == "Jean-Luc"
-    assert provider_record.email == "loc.amarysreunion@orange.fr"
-    assert provider_record.phone == "0692600544"
-    assert provider_record.function == "Gérant"
-    assert provider_record.newsletter is True
-    assert provider_record.address1 == "37 Chemin de la Concession les Bas"
-    assert provider_record.postcode == 97418
-    assert provider_record.city == "La Plaine des Cafres"


### PR DESCRIPTION
## Summary
- install the migration tool with its ai extra inside the Docker image so the OpenAI dependency is available at runtime
- ensure the provider agent creates actors through Supabase, captures returned identifiers, and registers them in the shared context for downstream agents
- treat legacy provider identifiers as external references while letting the AI transformation surface them and tests assert the new orchestration
- normalise workflow-added payload envelopes and capture submitting organisation identifiers so heterogeneous requests reach the agents in a consistent shape

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d53ad00ba88327add42dd46f9eb31e