### PR TITLE
Introduce reference code agent and tighten agent payload filtering

### DIFF
--- a/migration-tool/migration_tool/agents/amenities.py
+++ b/migration-tool/migration_tool/agents/amenities.py
@@ -26,6 +26,7 @@ class AmenitiesAgent(AIEnabledAgent):
             agent_name=self.name,
             payload=payload,
             response_model=AmenityTransformation,
+            context=context.snapshot(),
         )
         amenities: List[AmenityLinkRecord] = transformation.amenities
         self.telemetry.record(
@@ -51,6 +52,14 @@ class AmenitiesAgent(AIEnabledAgent):
                     on_conflict="object_id,amenity_id",
                 )
             )
+        context.share(
+            self.name,
+            {
+                "amenities": [amenity.model_dump() for amenity in amenities],
+                "responses": responses,
+            },
+            overwrite=True,
+        )
         return {
             "status": "ok",
             "operation": "upsert",

--- a/migration-tool/migration_tool/agents/coordinator.py
+++ b/migration-tool/migration_tool/agents/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from typing import Any, Dict, Iterable, List, Optional, Sequence
 
-from ..ai import FieldRouter
+from ..ai import FieldRouter, PromptLibrary
 from ..schemas import (
     AgentContext,
     FieldRoutingDecision,
@@ -26,6 +26,8 @@ from .payments import PaymentMethodAgent
 from .pet_policy import PetPolicyAgent
 from .providers import ProviderAgent
 from .schedule import ScheduleAgent
+from .verification import VerificationAgent
+from .reference_codes import ReferenceCodeAgent
 
 
 class Coordinator:
@@ -47,6 +49,9 @@ class Coordinator:
         webhook: WebhookNotifier,
         telemetry: EventLog,
         router: FieldRouter,
+        verification_agent: VerificationAgent,
+        prompt_library: PromptLibrary,
+        reference_agent: ReferenceCodeAgent,
     ) -> None:
         self.agents: Dict[str, Agent] = {
             "identity": identity_agent,
@@ -64,10 +69,15 @@ class Coordinator:
         self.webhook = webhook
         self.telemetry = telemetry
         self.router = router
+        self.verification_agent = verification_agent
+        self.prompt_library = prompt_library
+        self.reference_agent = reference_agent
 
     def descriptors(self) -> Iterable[Dict[str, Any]]:
         for name, agent in self.agents.items():
             yield agent.descriptor().model_dump()
+        yield self.verification_agent.descriptor().model_dump()
+        yield self.reference_agent.descriptor().model_dump()
 
     async def handle(self, payload: RawEstablishmentPayload) -> tuple[List[RoutedFragment], Dict[str, Any]]:
         coordinator_id = str(uuid.uuid4())
@@ -83,12 +93,50 @@ class Coordinator:
             payload=combined_payload,
             agent_descriptors=[agent.descriptor() for agent in self.agents.values()],
         )
+
+        fallback_sections, fallback_leftovers = partition_payload(combined_payload)
+
+        merged_sections: Dict[str, Dict[str, Any]] = {}
+        for name, section in decision.sections.items():
+            if section:
+                merged_sections[name] = dict(section)
+
+        for agent_name, fallback_section in fallback_sections.items():
+            target_section = merged_sections.setdefault(agent_name, {})
+            for field_name, value in fallback_section.items():
+                target_section.setdefault(field_name, value)
+
+        leftovers: Dict[str, Any] = dict(decision.leftovers)
+        ignored_leftover_keys = {
+            "name",
+            "dataProvidingOrg",
+            "source_organization_id",
+            "raw_batch",
+            "raw_blocks",
+            "raw_main_record",
+            "raw_additional_sections",
+            "raw_payload",
+        }
+        for key, value in fallback_leftovers.items():
+            if key in ignored_leftover_keys:
+                continue
+            leftovers.setdefault(key, value)
+
+        recognised_keys = {key for section in merged_sections.values() for key in section.keys()}
+        for key in list(leftovers.keys()):
+            if key in recognised_keys:
+                leftovers.pop(key)
+
+        decision.sections = merged_sections
+        decision.leftovers = leftovers
         context = AgentContext(
             coordinator_id=coordinator_id,
             source_payload=combined_payload,
             object_id=self._extract_initial_object_id(combined_payload, payload.legacy_ids),
             source_organization_id=payload.source_organization_id,
+            prompt_library=self.prompt_library,
         )
+        context.attach_reference_agent(self.reference_agent)
         fragments: List[RoutedFragment] = []
 
         self.telemetry.record(
@@ -112,9 +160,10 @@ class Coordinator:
             )
             if identity_payload:
                 section_payload = self._prepare_section_payload(
+                    identity_agent,
                     identity_payload,
                     payload,
-                    context.object_id,
+                    context,
                 )
                 self.telemetry.record(
                     "coordinator.agent_start.identity",
@@ -127,6 +176,22 @@ class Coordinator:
                     result = await identity_agent.handle(section_payload, context)
                     context.object_id = result.get("object_id") or context.object_id
                     context.duplicate_of = result.get("duplicate_of") or context.duplicate_of
+                    identity_state = context.recall("identity")
+                    identity_state.update(
+                        {
+                            "payload": section_payload,
+                            "result": result,
+                            "object_id": context.object_id,
+                            "duplicate_of": context.duplicate_of,
+                        }
+                    )
+                    context.share("identity", identity_state, overwrite=True)
+                    context.log_event(
+                        "identity",
+                        status="processed",
+                        payload=section_payload,
+                        result=result,
+                    )
                     fragments.append(
                         RoutedFragment(agent="identity", status="processed", payload=section_payload, message=None)
                     )
@@ -139,6 +204,15 @@ class Coordinator:
                         },
                     )
                 except Exception as exc:
+                    identity_state = context.recall("identity")
+                    identity_state.update({"payload": section_payload, "error": str(exc)})
+                    context.share("identity", identity_state, overwrite=True)
+                    context.log_event(
+                        "identity",
+                        status="error",
+                        payload=section_payload,
+                        error=str(exc),
+                    )
                     fragments.append(
                         RoutedFragment(agent="identity", status="error", payload=section_payload, message=str(exc))
                     )
@@ -160,9 +234,10 @@ class Coordinator:
                 continue
 
             section_payload = self._prepare_section_payload(
+                agent,
                 section_payload,
                 payload,
-                context.object_id,
+                context,
             )
 
             self.telemetry.record(
@@ -175,6 +250,21 @@ class Coordinator:
 
             try:
                 result = await agent.handle(section_payload, context)
+                agent_state = context.recall(name)
+                agent_state.update(
+                    {
+                        "payload": section_payload,
+                        "result": result,
+                        "object_id": context.object_id,
+                    }
+                )
+                context.share(name, agent_state, overwrite=True)
+                context.log_event(
+                    name,
+                    status="processed",
+                    payload=section_payload,
+                    result=result,
+                )
                 fragments.append(
                     RoutedFragment(agent=name, status="processed", payload=section_payload, message=None)
                 )
@@ -183,6 +273,15 @@ class Coordinator:
                     {"coordinator_id": coordinator_id, "payload": section_payload, "result": result},
                 )
             except Exception as exc:
+                agent_state = context.recall(name)
+                agent_state.update({"payload": section_payload, "error": str(exc)})
+                context.share(name, agent_state, overwrite=True)
+                context.log_event(
+                    name,
+                    status="error",
+                    payload=section_payload,
+                    error=str(exc),
+                )
                 fragments.append(
                     RoutedFragment(agent=name, status="error", payload=section_payload, message=str(exc))
                 )
@@ -199,29 +298,89 @@ class Coordinator:
                 "unresolved": leftovers,
             })
 
+        verification_payload = {
+            "fragments": [fragment.model_dump() for fragment in fragments],
+            "leftovers": leftovers,
+        }
+        self.telemetry.record(
+            "coordinator.agent_start.verification",
+            {"coordinator_id": coordinator_id, "payload": verification_payload},
+        )
+        try:
+            verification_result = await self.verification_agent.handle(verification_payload, context)
+            context.log_event(
+                "verification",
+                status="processed",
+                payload=verification_payload,
+                result=verification_result,
+            )
+            fragments.append(
+                RoutedFragment(agent="verification", status="processed", payload=verification_payload, message=None)
+            )
+            self.telemetry.record(
+                "coordinator.agent.verification",
+                {
+                    "coordinator_id": coordinator_id,
+                    "payload": verification_payload,
+                    "result": verification_result,
+                },
+            )
+        except Exception as exc:
+            context.log_event(
+                "verification",
+                status="error",
+                payload=verification_payload,
+                error=str(exc),
+            )
+            fragments.append(
+                RoutedFragment(agent="verification", status="error", payload=verification_payload, message=str(exc))
+            )
+            self.telemetry.record(
+                "coordinator.agent_error.verification",
+                {
+                    "coordinator_id": coordinator_id,
+                    "payload": verification_payload,
+                    "error": str(exc),
+                },
+            )
+
         return fragments, leftovers
 
     def _prepare_section_payload(
         self,
+        agent: Agent,
         section_payload: Dict[str, Any],
         payload: RawEstablishmentPayload,
-        object_id: Optional[str],
+        context: AgentContext,
     ) -> Dict[str, Any]:
-        enriched = dict(section_payload)
-        if object_id:
-            enriched.setdefault("establishment_id", object_id)
-            enriched.setdefault("object_id", object_id)
+        allowed_keys = set(agent.expected_fields or [])
+        enriched = {
+            key: value
+            for key, value in section_payload.items()
+            if not allowed_keys or key in allowed_keys
+        }
+
+        if agent.name == "identity":
+            defaults: Dict[str, Any] = {}
+            if payload.establishment_name:
+                defaults["establishment_name"] = payload.establishment_name
+            if payload.establishment_category:
+                defaults["category"] = payload.establishment_category
+            if payload.establishment_subcategory:
+                defaults["subcategory"] = payload.establishment_subcategory
+            if payload.legacy_ids is not None:
+                defaults["legacy_ids"] = payload.legacy_ids
+            if payload.source_organization_id:
+                defaults["source_organization_id"] = payload.source_organization_id
+            for key, value in defaults.items():
+                enriched.setdefault(key, value)
         else:
-            enriched.setdefault("establishment_id", None)
-        enriched.setdefault("establishment_name", payload.establishment_name)
-        enriched.setdefault("category", payload.establishment_category)
-        enriched.setdefault("subcategory", payload.establishment_subcategory)
-        if payload.legacy_ids is not None:
-            enriched.setdefault("legacy_ids", payload.legacy_ids)
-        else:
-            enriched.setdefault("legacy_ids", [])
-        if payload.source_organization_id:
-            enriched.setdefault("source_organization_id", payload.source_organization_id)
+            if context.object_id:
+                if "establishment_id" in allowed_keys:
+                    enriched.setdefault("establishment_id", context.object_id)
+                if "object_id" in allowed_keys:
+                    enriched.setdefault("object_id", context.object_id)
+
         return enriched
 
     def _build_identity_payload(

--- a/migration-tool/migration_tool/agents/identity.py
+++ b/migration-tool/migration_tool/agents/identity.py
@@ -37,6 +37,7 @@ class IdentityAgent(AIEnabledAgent):
             agent_name=self.name,
             payload=payload,
             response_model=IdentityRecord,
+            context=context.snapshot(),
         )
 
         if record.object_id and not OBJECT_ID_PATTERN.match(record.object_id):
@@ -101,6 +102,17 @@ class IdentityAgent(AIEnabledAgent):
                     "longitude": longitude,
                 },
             )
+
+        context.share(
+            self.name,
+            {
+                "record": record.model_dump(),
+                "object_id": context.object_id,
+                "duplicate_of": context.duplicate_of,
+                "matched_existing": matched_existing,
+            },
+            overwrite=True,
+        )
 
         return {
             "status": "ok",

--- a/migration-tool/migration_tool/agents/languages.py
+++ b/migration-tool/migration_tool/agents/languages.py
@@ -26,6 +26,7 @@ class LanguageAgent(AIEnabledAgent):
             agent_name=self.name,
             payload=payload,
             response_model=LanguageTransformation,
+            context=context.snapshot(),
         )
         responses = []
         for record in transformation.languages:
@@ -41,7 +42,7 @@ class LanguageAgent(AIEnabledAgent):
             )
             level_id: Optional[str] = None
             if record.proficiency_code:
-                level_id = await self.supabase.ensure_code(
+                level_id = await context.ensure_reference_code(
                     domain="language_level",
                     code=record.proficiency_code,
                     name=record.proficiency_code.replace("_", " ").title(),
@@ -63,6 +64,15 @@ class LanguageAgent(AIEnabledAgent):
                 "payload": payload,
                 "languages": [record.model_dump() for record in transformation.languages],
             },
+        )
+
+        context.share(
+            self.name,
+            {
+                "languages": [record.model_dump() for record in transformation.languages],
+                "responses": responses,
+            },
+            overwrite=True,
         )
 
         return {

--- a/migration-tool/migration_tool/agents/location.py
+++ b/migration-tool/migration_tool/agents/location.py
@@ -35,6 +35,7 @@ class LocationAgent(AIEnabledAgent):
             agent_name=self.name,
             payload=payload,
             response_model=LocationTransformation,
+            context=context.snapshot(),
         )
         locations: List[LocationRecord] = transformation.locations
         self.telemetry.record(
@@ -52,6 +53,15 @@ class LocationAgent(AIEnabledAgent):
             responses.append(
                 await self.supabase.upsert("object_location", record.to_supabase())
             )
+
+        context.share(
+            self.name,
+            {
+                "locations": [record.model_dump() for record in locations],
+                "responses": responses,
+            },
+            overwrite=True,
+        )
         return {
             "status": "ok",
             "operation": "upsert",

--- a/migration-tool/migration_tool/agents/media.py
+++ b/migration-tool/migration_tool/agents/media.py
@@ -26,6 +26,7 @@ class MediaAgent(AIEnabledAgent):
             agent_name=self.name,
             payload=payload,
             response_model=MediaTransformation,
+            context=context.snapshot(),
         )
         media: List[MediaRecord] = transformation.media
         self.telemetry.record(
@@ -42,9 +43,12 @@ class MediaAgent(AIEnabledAgent):
                 continue
             original_media_type = item.media_type_code or "image"
             normalized_media_type = self.supabase.normalize_code(original_media_type)
-            media_type_id = await self.supabase.lookup("ref_code_media_type", code=normalized_media_type)
+            media_type_id = await context.lookup_reference_code(
+                domain="media_type",
+                code=normalized_media_type,
+            )
             if not media_type_id:
-                media_type_id = await self.supabase.ensure_code(
+                media_type_id = await context.ensure_reference_code(
                     domain="media_type",
                     code=normalized_media_type,
                     name=original_media_type.replace("_", " ").title(),
@@ -56,6 +60,14 @@ class MediaAgent(AIEnabledAgent):
                     item.to_supabase(media_type_id=media_type_id),
                 )
             )
+        context.share(
+            self.name,
+            {
+                "media": [item.model_dump() for item in media],
+                "responses": responses,
+            },
+            overwrite=True,
+        )
         return {
             "status": "ok",
             "operation": "upsert",

--- a/migration-tool/migration_tool/agents/pet_policy.py
+++ b/migration-tool/migration_tool/agents/pet_policy.py
@@ -26,9 +26,15 @@ class PetPolicyAgent(AIEnabledAgent):
             agent_name=self.name,
             payload=payload,
             response_model=PetPolicyTransformation,
+            context=context.snapshot(),
         )
         record = transformation.pet_policy
         if not record or record.accepted is None and not record.conditions:
+            context.share(
+                self.name,
+                {"pet_policy": None, "status": "no_data"},
+                overwrite=True,
+            )
             return {
                 "status": "ok",
                 "operation": "no_data",
@@ -49,6 +55,15 @@ class PetPolicyAgent(AIEnabledAgent):
                 "payload": payload,
                 "pet_policy": record.model_dump() if record else None,
             },
+        )
+
+        context.share(
+            self.name,
+            {
+                "pet_policy": record.model_dump(),
+                "response": response,
+            },
+            overwrite=True,
         )
 
         return {

--- a/migration-tool/migration_tool/agents/reference_codes.py
+++ b/migration-tool/migration_tool/agents/reference_codes.py
@@ -1,0 +1,96 @@
+"""Agent responsible for managing and caching reference codes."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from ..schemas import AgentContext
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import Agent
+
+
+class ReferenceCodeAgent(Agent):
+    name = "reference_codes"
+    description = "Provides cached lookup/creation of reference codes across agents."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog) -> None:
+        super().__init__()
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = ["requests"]
+        self._memory: Dict[Tuple[str, str], Optional[str]] = {}
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        raw_requests = payload.get("requests", [])
+        if isinstance(raw_requests, dict):
+            request_list: List[Any] = [raw_requests]
+        elif isinstance(raw_requests, Iterable):
+            request_list = list(raw_requests)
+        else:
+            request_list = []
+
+        results: List[Dict[str, Any]] = []
+        for request in request_list:
+            if not isinstance(request, dict):
+                continue
+            domain = request.get("domain")
+            code = request.get("code")
+            if not domain or not code:
+                continue
+            identifier = await self.ensure(
+                domain=domain,
+                code=str(code),
+                name=request.get("name"),
+                description=request.get("description"),
+                metadata=request.get("metadata"),
+            )
+            results.append({"domain": domain, "code": code, "id": identifier})
+
+        context.share(
+            self.name,
+            {"requests": request_list, "results": results},
+            overwrite=True,
+        )
+        return {"status": "ok", "operation": "lookup", "results": results}
+
+    async def ensure(
+        self,
+        *,
+        domain: str,
+        code: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        normalized = self.supabase.normalize_code(code)
+        cache_key = (domain, normalized)
+        if cache_key in self._memory:
+            return self._memory[cache_key]
+
+        identifier = await self.supabase.lookup(f"ref_code_{domain}", code=normalized)
+        if identifier:
+            self._memory[cache_key] = identifier
+            return identifier
+
+        identifier = await self.supabase.ensure_code(
+            domain=domain,
+            code=normalized,
+            name=name or code,
+            description=description,
+            metadata=metadata,
+        )
+        self._memory[cache_key] = identifier
+        return identifier
+
+    async def lookup(self, *, domain: str, code: str) -> Optional[str]:
+        normalized = self.supabase.normalize_code(code)
+        cache_key = (domain, normalized)
+        if cache_key in self._memory:
+            return self._memory[cache_key]
+        identifier = await self.supabase.lookup(f"ref_code_{domain}", code=normalized)
+        self._memory[cache_key] = identifier
+        return identifier
+
+
+__all__ = ["ReferenceCodeAgent"]

--- a/migration-tool/migration_tool/agents/verification.py
+++ b/migration-tool/migration_tool/agents/verification.py
@@ -1,0 +1,79 @@
+"""Agent supervising inserts and prompt adjustments."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..ai import PromptLibrary
+from ..schemas import AgentContext
+from ..telemetry import EventLog
+from .base import Agent
+
+
+class VerificationAgent(Agent):
+    """Monitor agent outcomes and tune prompts when issues repeat."""
+
+    name = "verification"
+    description = (
+        "Analyses routed fragments, tracks recurring Supabase errors, and adjusts"
+        " agent prompting guidance so data flows into the correct tables."
+    )
+
+    def __init__(
+        self,
+        telemetry: EventLog,
+        prompts: PromptLibrary,
+        *,
+        threshold: int = 3,
+    ) -> None:
+        super().__init__()
+        self.telemetry = telemetry
+        self.prompts = prompts
+        self.threshold = max(1, threshold)
+        self.expected_fields = []
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        fragments: List[Dict[str, Any]] = payload.get("fragments", [])
+        leftovers: Dict[str, Any] = payload.get("leftovers", {})
+        observed_agents = list(context.agent_events.keys())
+        adjustments: List[Dict[str, Any]] = []
+
+        for agent_name in observed_agents:
+            summary = self.prompts.error_summary(agent_name)
+            if summary["count"] >= self.threshold and summary["messages"]:
+                guidance = (
+                    "Focus on resolving these recurring validation issues: "
+                    + "; ".join(summary["messages"][-3:])
+                    + ". Ensure emitted rows respect Supabase relations and constraints."
+                )
+                self.prompts.set_guidance(agent_name, guidance)
+                adjustments.append(
+                    {
+                        "agent": agent_name,
+                        "guidance": guidance,
+                        "errors": summary,
+                    }
+                )
+                self.telemetry.record(
+                    "agent.verification.prompt_adjusted",
+                    {
+                        "agent": agent_name,
+                        "guidance": guidance,
+                        "errors": summary,
+                        "coordinator_id": context.coordinator_id,
+                    },
+                )
+                self.prompts.reset_errors(agent_name)
+
+        review = {
+            "status": "ok",
+            "observed_agents": observed_agents,
+            "fragments_reviewed": fragments,
+            "leftovers": leftovers,
+            "adjustments": adjustments,
+        }
+        context.share(self.name, review, overwrite=True)
+        return review
+
+
+__all__ = ["VerificationAgent"]

--- a/migration-tool/tests/test_ai_providers_schedule.py
+++ b/migration-tool/tests/test_ai_providers_schedule.py
@@ -1,6 +1,6 @@
 import pytest
 
-from migration_tool.ai import RuleBasedLLM
+from migration_tool.ai import PromptLibrary, RuleBasedLLM
 from migration_tool.agents.providers import ProviderAgent
 from migration_tool.agents.schedule import ScheduleAgent
 from migration_tool.schemas import AgentContext, ProviderTransformation, ScheduleTransformation
@@ -65,13 +65,19 @@ async def test_provider_agent_ai_transformation() -> None:
             }
         ]
     }
-    context = AgentContext(coordinator_id="test", source_payload=payload, object_id="reccZJ9INTTb7Mxtg")
+    context = AgentContext(
+        coordinator_id="test",
+        source_payload=payload,
+        object_id="reccZJ9INTTb7Mxtg",
+        prompt_library=PromptLibrary(),
+    )
 
     # Test AI transformation directly
     transformation = await llm.transform_fragment(
         agent_name="providers",
         payload=payload,
         response_model=ProviderTransformation,
+        context={},
     )
 
     assert isinstance(transformation, ProviderTransformation)
@@ -136,13 +142,19 @@ async def test_schedule_agent_ai_transformation() -> None:
             }
         ]
     }
-    context = AgentContext(coordinator_id="test", source_payload=payload, object_id="reccZJ9INTTb7Mxtg")
+    context = AgentContext(
+        coordinator_id="test",
+        source_payload=payload,
+        object_id="reccZJ9INTTb7Mxtg",
+        prompt_library=PromptLibrary(),
+    )
 
     # Test AI transformation directly
     transformation = await llm.transform_fragment(
         agent_name="schedule",
         payload=payload,
         response_model=ScheduleTransformation,
+        context={},
     )
 
     assert isinstance(transformation, ScheduleTransformation)

--- a/migration-tool/tests/test_ai_routing.py
+++ b/migration-tool/tests/test_ai_routing.py
@@ -1,7 +1,6 @@
 import pytest
-import pytest
 
-from migration_tool.ai import FieldRouter, RuleBasedLLM
+from migration_tool.ai import FieldRouter, PromptLibrary, RuleBasedLLM
 from migration_tool.agents.environment import EnvironmentAgent
 from migration_tool.agents.identity import IdentityAgent
 from migration_tool.agents.languages import LanguageAgent
@@ -10,6 +9,22 @@ from migration_tool.agents.pet_policy import PetPolicyAgent
 from migration_tool.schemas import AgentContext, AgentDescriptor
 from migration_tool.supabase_client import SupabaseService
 from migration_tool.telemetry import EventLog
+
+
+class ReferenceAgentStub:
+    async def ensure(
+        self,
+        *,
+        domain: str,
+        code: str,
+        name: str | None = None,
+        description: str | None = None,
+        metadata: dict | None = None,
+    ) -> str:
+        return f"{domain}:{code}"
+
+    async def lookup(self, *, domain: str, code: str) -> str | None:
+        return f"{domain}:{code}"
 
 
 @pytest.fixture
@@ -55,7 +70,12 @@ async def test_identity_agent_rule_based_transformation() -> None:
         "legacy_ids": ["LEGACY-1"],
         "description": "Bel établissement au centre-ville",
     }
-    context = AgentContext(coordinator_id="coord", source_payload=payload)
+    context = AgentContext(
+        coordinator_id="coord",
+        source_payload=payload,
+        prompt_library=PromptLibrary(),
+    )
+    context.attach_reference_agent(ReferenceAgentStub())
 
     result = await agent.handle(payload, context)
 
@@ -72,7 +92,13 @@ async def test_language_agent_rule_based_transformation() -> None:
     agent = LanguageAgent(supabase, telemetry, llm)
 
     payload = {"establishment_id": "OBJ1", "languages": ["Français", "Anglais"]}
-    context = AgentContext(coordinator_id="coord", source_payload=payload, object_id="OBJ1")
+    context = AgentContext(
+        coordinator_id="coord",
+        source_payload=payload,
+        object_id="OBJ1",
+        prompt_library=PromptLibrary(),
+    )
+    context.attach_reference_agent(ReferenceAgentStub())
 
     result = await agent.handle(payload, context)
 
@@ -89,7 +115,13 @@ async def test_payment_agent_rule_based_transformation() -> None:
     agent = PaymentMethodAgent(supabase, telemetry, llm)
 
     payload = {"establishment_id": "OBJ1", "payment_methods": ["Carte Bancaire", "Espèces"]}
-    context = AgentContext(coordinator_id="coord", source_payload=payload, object_id="OBJ1")
+    context = AgentContext(
+        coordinator_id="coord",
+        source_payload=payload,
+        object_id="OBJ1",
+        prompt_library=PromptLibrary(),
+    )
+    context.attach_reference_agent(ReferenceAgentStub())
 
     result = await agent.handle(payload, context)
 
@@ -106,7 +138,13 @@ async def test_environment_agent_rule_based_transformation() -> None:
     agent = EnvironmentAgent(supabase, telemetry, llm)
 
     payload = {"establishment_id": "OBJ1", "environment_tags": ["Village", "Milieu rural"]}
-    context = AgentContext(coordinator_id="coord", source_payload=payload, object_id="OBJ1")
+    context = AgentContext(
+        coordinator_id="coord",
+        source_payload=payload,
+        object_id="OBJ1",
+        prompt_library=PromptLibrary(),
+    )
+    context.attach_reference_agent(ReferenceAgentStub())
 
     result = await agent.handle(payload, context)
 
@@ -123,7 +161,12 @@ async def test_pet_policy_agent_rule_based_transformation() -> None:
     agent = PetPolicyAgent(supabase, telemetry, llm)
 
     payload = {"establishment_id": "OBJ1", "pets_allowed": "oui"}
-    context = AgentContext(coordinator_id="coord", source_payload=payload, object_id="OBJ1")
+    context = AgentContext(
+        coordinator_id="coord",
+        source_payload=payload,
+        object_id="OBJ1",
+        prompt_library=PromptLibrary(),
+    )
 
     result = await agent.handle(payload, context)
 

--- a/migration-tool/tests/test_coordinator_identity_flow.py
+++ b/migration-tool/tests/test_coordinator_identity_flow.py
@@ -1,10 +1,13 @@
 import pytest
 
+from migration_tool.ai import PromptLibrary
+
 from migration_tool.agents.base import Agent
 from migration_tool.agents.coordinator import Coordinator
 from migration_tool.schemas import FieldRoutingDecision, RawEstablishmentPayload
 from migration_tool.telemetry import EventLog
 from migration_tool.webhook import WebhookNotifier
+from migration_tool.agents.verification import VerificationAgent
 
 
 pytestmark = pytest.mark.anyio("asyncio")
@@ -31,10 +34,20 @@ class IdentityStub(Agent):
         self.generated_id = generated_id
         self.calls: list[dict[str, object]] = []
         self.expected_fields = ["establishment_name"]
+        self.shared: list[dict[str, object]] = []
 
     async def handle(self, payload, context):
         self.calls.append(payload)
         context.object_id = payload.get("establishment_id") or self.generated_id
+        context.share(
+            self.name,
+            {
+                "payload": payload,
+                "object_id": context.object_id,
+            },
+            overwrite=True,
+        )
+        self.shared.append(context.recall(self.name))
         return {"object_id": context.object_id}
 
 
@@ -46,11 +59,53 @@ class RecordingStub(Agent):
         self.expected_fields = []
         self.calls: list[dict[str, object]] = []
         self.object_ids: list[object] = []
+        self.recalled_identity: list[dict[str, object]] = []
+        self.shared_snapshots: list[dict[str, object]] = []
 
     async def handle(self, payload, context):
         self.calls.append(payload)
         self.object_ids.append(context.object_id)
+        self.recalled_identity.append(context.recall("identity"))
+        context.share(
+            self.name,
+            {
+                "payload": payload,
+                "object_id": context.object_id,
+            },
+            overwrite=True,
+        )
+        self.shared_snapshots.append(context.recall(self.name))
         return {"status": "ok", "agent": self.name}
+
+
+class ReferenceAgentStub(Agent):
+    name = "reference_codes"
+    description = "stub"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.expected_fields = ["requests"]
+        self.created: dict[tuple[str, str], str] = {}
+
+    async def handle(self, payload, context):  # pragma: no cover - unused in tests
+        return {"status": "ok"}
+
+    async def ensure(
+        self,
+        *,
+        domain: str,
+        code: str,
+        name: str | None = None,
+        description: str | None = None,
+        metadata: dict | None = None,
+    ) -> str:
+        key = (domain, code)
+        if key not in self.created:
+            self.created[key] = f"{domain}:{code}"
+        return self.created[key]
+
+    async def lookup(self, *, domain: str, code: str) -> str | None:
+        return self.created.get((domain, code))
 
 
 @pytest.fixture
@@ -82,6 +137,8 @@ async def test_identity_id_propagation_when_router_omits_section():
     router = StubRouter({"contact": {"phone": ["0262275287"]}})
     telemetry = EventLog()
     webhook = WebhookNotifier(url=None, telemetry=telemetry)
+    prompt_library = PromptLibrary()
+    verification_agent = VerificationAgent(telemetry, prompt_library)
 
     coordinator = Coordinator(
         identity_agent=identity_agent,
@@ -98,6 +155,9 @@ async def test_identity_id_propagation_when_router_omits_section():
         webhook=webhook,
         telemetry=telemetry,
         router=router,
+        verification_agent=verification_agent,
+        prompt_library=prompt_library,
+        reference_agent=ReferenceAgentStub(),
     )
 
     fragments, leftovers = await coordinator.handle(sample_payload)
@@ -105,7 +165,124 @@ async def test_identity_id_propagation_when_router_omits_section():
     assert leftovers == {}
     assert any(fragment.agent == "identity" for fragment in fragments)
     assert contact_agent.object_ids[0] == identity_agent.generated_id
-    assert contact_agent.calls[0]["establishment_id"] == identity_agent.generated_id
+    assert "establishment_id" not in contact_agent.calls[0]
     assert identity_agent.calls[0]["establishment_name"] == sample_payload.establishment_name
     assert identity_agent.calls[0]["legacy_ids"] == []
+
+
+@pytest.mark.anyio
+async def test_fallback_partition_routes_recognised_fields():
+    sample_payload = RawEstablishmentPayload.model_validate(
+        {
+            "name": "Chez Partition",
+            "category": "Restaurant",
+            "subcategory": "Brasserie",
+            "data": {
+                "phone": "0262275287",
+                "address_line1": "1 Rue du Port",
+                "city": "Saint-Denis",
+                "unknown": "keep-me",
+            },
+        }
+    )
+
+    identity_agent = IdentityStub()
+    location_agent = RecordingStub("location")
+    contact_agent = RecordingStub("contact")
+    router = StubRouter({})
+    telemetry = EventLog()
+    webhook = WebhookNotifier(url=None, telemetry=telemetry)
+    prompt_library = PromptLibrary()
+    verification_agent = VerificationAgent(telemetry, prompt_library)
+
+    coordinator = Coordinator(
+        identity_agent=identity_agent,
+        location_agent=location_agent,
+        contact_agent=contact_agent,
+        amenities_agent=RecordingStub("amenities"),
+        language_agent=RecordingStub("languages"),
+        payment_agent=RecordingStub("payments"),
+        environment_agent=RecordingStub("environment"),
+        pet_policy_agent=RecordingStub("pet_policy"),
+        media_agent=RecordingStub("media"),
+        provider_agent=RecordingStub("providers"),
+        schedule_agent=RecordingStub("schedule"),
+        webhook=webhook,
+        telemetry=telemetry,
+        router=router,
+        verification_agent=verification_agent,
+        prompt_library=prompt_library,
+        reference_agent=ReferenceAgentStub(),
+    )
+
+    fragments, leftovers = await coordinator.handle(sample_payload)
+
+    assert leftovers == {"unknown": "keep-me"}
+    assert location_agent.calls
+    assert location_agent.calls[0]["address_line1"] == "1 Rue du Port"
+    assert contact_agent.calls
+    assert contact_agent.calls[0]["phone"] == "0262275287"
+    processed_agents = {fragment.agent for fragment in fragments}
+    assert "location" in processed_agents
+    assert "contact" in processed_agents
+
+
+@pytest.mark.anyio
+async def test_agents_can_share_state_via_context():
+    sample_payload = RawEstablishmentPayload.model_validate(
+        {
+            "name": "Maison Partagée",
+            "establishment_name": "Maison Partagée",
+            "data": {
+                "address_line1": "5 Rue du Port",
+                "phone": ["0262000000"],
+            },
+        }
+    )
+
+    identity_agent = IdentityStub()
+    location_agent = RecordingStub("location")
+    contact_agent = RecordingStub("contact")
+    router = StubRouter(
+        {
+            "identity": {"establishment_name": "Maison Partagée"},
+            "location": {"address_line1": "5 Rue du Port"},
+            "contact": {"phone": ["0262000000"]},
+        }
+    )
+    telemetry = EventLog()
+    webhook = WebhookNotifier(url=None, telemetry=telemetry)
+    prompt_library = PromptLibrary()
+    verification_agent = VerificationAgent(telemetry, prompt_library)
+
+    coordinator = Coordinator(
+        identity_agent=identity_agent,
+        location_agent=location_agent,
+        contact_agent=contact_agent,
+        amenities_agent=RecordingStub("amenities"),
+        language_agent=RecordingStub("languages"),
+        payment_agent=RecordingStub("payments"),
+        environment_agent=RecordingStub("environment"),
+        pet_policy_agent=RecordingStub("pet_policy"),
+        media_agent=RecordingStub("media"),
+        provider_agent=RecordingStub("providers"),
+        schedule_agent=RecordingStub("schedule"),
+        webhook=webhook,
+        telemetry=telemetry,
+        router=router,
+        verification_agent=verification_agent,
+        prompt_library=prompt_library,
+        reference_agent=ReferenceAgentStub(),
+    )
+
+    fragments, leftovers = await coordinator.handle(sample_payload)
+
+    assert leftovers == {}
+    assert identity_agent.shared[-1]["object_id"] == identity_agent.generated_id
+    assert contact_agent.recalled_identity[-1]["object_id"] == identity_agent.generated_id
+    assert location_agent.recalled_identity[-1]["object_id"] == identity_agent.generated_id
+    assert contact_agent.shared_snapshots[-1]["payload"]["phone"] == ["0262000000"]
+    assert location_agent.shared_snapshots[-1]["payload"]["address_line1"] == "5 Rue du Port"
+    routed_agents = {fragment.agent for fragment in fragments}
+    assert routed_agents.issuperset({"identity", "contact", "location"})
 

--- a/migration-tool/tests/test_providers_schedule.py
+++ b/migration-tool/tests/test_providers_schedule.py
@@ -2,7 +2,7 @@ import types
 
 import pytest
 
-from migration_tool.ai import RuleBasedLLM
+from migration_tool.ai import PromptLibrary, RuleBasedLLM
 from migration_tool.agents.providers import ProviderAgent
 from migration_tool.agents.schedule import ScheduleAgent
 from migration_tool.schemas import AgentContext
@@ -45,7 +45,12 @@ async def test_provider_agent_processes_nested_payload() -> None:
             }
         ],
     }
-    context = AgentContext(coordinator_id="test", source_payload=payload, object_id="reccZJ9INTTb7Mxtg")
+    context = AgentContext(
+        coordinator_id="test",
+        source_payload=payload,
+        object_id="reccZJ9INTTb7Mxtg",
+        prompt_library=PromptLibrary(),
+    )
 
     result = await agent.handle(payload, context)
 
@@ -93,7 +98,12 @@ async def test_provider_agent_uses_returned_identifier() -> None:
             }
         ],
     }
-    context = AgentContext(coordinator_id="test", source_payload=payload, object_id="obj-1")
+    context = AgentContext(
+        coordinator_id="test",
+        source_payload=payload,
+        object_id="obj-1",
+        prompt_library=PromptLibrary(),
+    )
 
     result = await agent.handle(payload, context)
 
@@ -126,7 +136,12 @@ async def test_schedule_agent_processes_nested_payload() -> None:
             }
         ],
     }
-    context = AgentContext(coordinator_id="test", source_payload=payload, object_id="reccZJ9INTTb7Mxtg")
+    context = AgentContext(
+        coordinator_id="test",
+        source_payload=payload,
+        object_id="reccZJ9INTTb7Mxtg",
+        prompt_library=PromptLibrary(),
+    )
 
     result = await agent.handle(payload, context)
 


### PR DESCRIPTION
## Summary
- add a dedicated ReferenceCodeAgent with shared caching and context helpers for ref_code lookups
- filter coordinator fragments down to expected fields and register the reference agent on every run
- update specialised agents, docs, and tests to resolve codes through the shared helper and avoid extraneous payload data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d620645d1883279cca9787e4d305bf