### PR TITLE
Tighten agent object ID propagation and align payloads with existing schema

### DIFF
--- a/migration-tool/migration_tool/agents/environment.py
+++ b/migration-tool/migration_tool/agents/environment.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from ..ai import LLMClient
 from ..schemas import AgentContext, EnvironmentTagTransformation
@@ -26,20 +26,67 @@ class EnvironmentAgent(AIEnabledAgent):
             agent_name=self.name,
             payload=payload,
             response_model=EnvironmentTagTransformation,
+            context=context.snapshot(),
         )
-        responses = []
+        responses: List[Dict[str, Any]] = []
+        skipped: List[Dict[str, Any]] = []
         for record in transformation.environment_tags:
             environment_code = (record.environment_code or "").strip()
             if not environment_code and record.environment_name:
                 environment_code = self.supabase.normalize_code(record.environment_name)
             if not environment_code:
+                skipped.append(
+                    {
+                        "tag": record.model_dump(),
+                        "reason": "missing_environment_code",
+                    }
+                )
+                self.telemetry.record(
+                    "agent.environment.skip_missing_code",
+                    {
+                        "context": context.model_dump(),
+                        "tag": record.model_dump(),
+                    },
+                )
                 continue
 
-            tag_id = await self.supabase.ensure_code(
+            record.object_id = record.object_id or context.object_id
+            if not record.object_id:
+                skipped.append(
+                    {
+                        "tag": record.model_dump(),
+                        "reason": "missing_object_id",
+                    }
+                )
+                self.telemetry.record(
+                    "agent.environment.skip_missing_object_id",
+                    {
+                        "context": context.model_dump(),
+                        "tag": record.model_dump(),
+                    },
+                )
+                continue
+
+            tag_id = await context.ensure_reference_code(
                 domain="environment_tag",
                 code=environment_code,
                 name=record.environment_name or environment_code.replace("_", " ").title(),
             )
+            if not tag_id:
+                skipped.append(
+                    {
+                        "tag": record.model_dump(),
+                        "reason": "unresolved_environment_tag",
+                    }
+                )
+                self.telemetry.record(
+                    "agent.environment.skip_unresolved_tag",
+                    {
+                        "context": context.model_dump(),
+                        "tag": record.model_dump(),
+                    },
+                )
+                continue
             data = record.to_supabase(environment_tag_id=tag_id)
             responses.append(
                 await self.supabase.upsert(
@@ -58,11 +105,24 @@ class EnvironmentAgent(AIEnabledAgent):
             },
         )
 
+        context.share(
+            self.name,
+            {
+                "environment_tags": [
+                    record.model_dump() for record in transformation.environment_tags
+                ],
+                "responses": responses,
+                "skipped": skipped,
+            },
+            overwrite=True,
+        )
+
         return {
             "status": "ok",
             "operation": "upsert",
             "table": "object_environment_tag",
             "responses": responses,
+            "skipped": skipped,
         }
 
 

--- a/migration-tool/migration_tool/agents/languages.py
+++ b/migration-tool/migration_tool/agents/languages.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from ..ai import LLMClient
 from ..schemas import AgentContext, LanguageTransformation
@@ -26,22 +26,75 @@ class LanguageAgent(AIEnabledAgent):
             agent_name=self.name,
             payload=payload,
             response_model=LanguageTransformation,
+            context=context.snapshot(),
         )
-        responses = []
+        responses: List[Dict[str, Any]] = []
+        skipped: List[Dict[str, Any]] = []
         for record in transformation.languages:
             language_code = (record.language_code or "").strip()
             if not language_code and record.language_name:
                 language_code = self.supabase.normalize_code(record.language_name)
             if not language_code:
+                skipped.append(
+                    {
+                        "language": record.model_dump(),
+                        "reason": "missing_language_code",
+                    }
+                )
+                self.telemetry.record(
+                    "agent.languages.skip_missing_code",
+                    {
+                        "context": context.model_dump(),
+                        "language": record.model_dump(),
+                    },
+                )
+                continue
+
+            record.object_id = record.object_id or context.object_id
+            if not record.object_id:
+                skipped.append(
+                    {
+                        "language": record.model_dump(),
+                        "reason": "missing_object_id",
+                    }
+                )
+                self.telemetry.record(
+                    "agent.languages.skip_missing_object_id",
+                    {
+                        "context": context.model_dump(),
+                        "language": record.model_dump(),
+                    },
+                )
                 continue
 
             language_id = await self.supabase.ensure_language(
                 code=language_code,
                 name=record.language_name,
             )
+            if not language_id and not self.supabase.client:
+                language_id = await context.ensure_reference_code(
+                    domain="language",
+                    code=language_code,
+                    name=record.language_name or language_code.upper(),
+                )
+            if not language_id:
+                skipped.append(
+                    {
+                        "language": record.model_dump(),
+                        "reason": "unresolved_language",
+                    }
+                )
+                self.telemetry.record(
+                    "agent.languages.skip_unresolved_language",
+                    {
+                        "context": context.model_dump(),
+                        "language": record.model_dump(),
+                    },
+                )
+                continue
             level_id: Optional[str] = None
             if record.proficiency_code:
-                level_id = await self.supabase.ensure_code(
+                level_id = await context.ensure_reference_code(
                     domain="language_level",
                     code=record.proficiency_code,
                     name=record.proficiency_code.replace("_", " ").title(),
@@ -65,11 +118,22 @@ class LanguageAgent(AIEnabledAgent):
             },
         )
 
+        context.share(
+            self.name,
+            {
+                "languages": [record.model_dump() for record in transformation.languages],
+                "responses": responses,
+                "skipped": skipped,
+            },
+            overwrite=True,
+        )
+
         return {
             "status": "ok",
             "operation": "upsert",
             "table": "object_language",
             "responses": responses,
+            "skipped": skipped,
         }
 
 

--- a/migration-tool/migration_tool/agents/pet_policy.py
+++ b/migration-tool/migration_tool/agents/pet_policy.py
@@ -26,13 +26,44 @@ class PetPolicyAgent(AIEnabledAgent):
             agent_name=self.name,
             payload=payload,
             response_model=PetPolicyTransformation,
+            context=context.snapshot(),
         )
         record = transformation.pet_policy
         if not record or record.accepted is None and not record.conditions:
+            context.share(
+                self.name,
+                {"pet_policy": None, "status": "no_data"},
+                overwrite=True,
+            )
             return {
                 "status": "ok",
                 "operation": "no_data",
                 "message": "No pet policy information provided",
+            }
+
+        record.object_id = record.object_id or context.object_id
+        if not record.object_id:
+            self.telemetry.record(
+                "agent.pet_policy.skip_missing_object_id",
+                {
+                    "context": context.model_dump(),
+                    "payload": payload,
+                    "record": record.model_dump(),
+                },
+            )
+            context.share(
+                self.name,
+                {
+                    "pet_policy": record.model_dump(),
+                    "status": "skipped",
+                    "reason": "missing_object_id",
+                },
+                overwrite=True,
+            )
+            return {
+                "status": "ok",
+                "operation": "skipped",
+                "message": "Pet policy skipped due to missing object identifier",
             }
 
         data = record.to_supabase()
@@ -49,6 +80,15 @@ class PetPolicyAgent(AIEnabledAgent):
                 "payload": payload,
                 "pet_policy": record.model_dump() if record else None,
             },
+        )
+
+        context.share(
+            self.name,
+            {
+                "pet_policy": record.model_dump(),
+                "response": response,
+            },
+            overwrite=True,
         )
 
         return {

--- a/migration-tool/migration_tool/agents/reference_codes.py
+++ b/migration-tool/migration_tool/agents/reference_codes.py
@@ -1,0 +1,96 @@
+"""Agent responsible for managing and caching reference codes."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from ..schemas import AgentContext
+from ..supabase_client import SupabaseService
+from ..telemetry import EventLog
+from .base import Agent
+
+
+class ReferenceCodeAgent(Agent):
+    name = "reference_codes"
+    description = "Provides cached lookup/creation of reference codes across agents."
+
+    def __init__(self, supabase: SupabaseService, telemetry: EventLog) -> None:
+        super().__init__()
+        self.supabase = supabase
+        self.telemetry = telemetry
+        self.expected_fields = ["requests"]
+        self._memory: Dict[Tuple[str, str], Optional[str]] = {}
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        raw_requests = payload.get("requests", [])
+        if isinstance(raw_requests, dict):
+            request_list: List[Any] = [raw_requests]
+        elif isinstance(raw_requests, Iterable):
+            request_list = list(raw_requests)
+        else:
+            request_list = []
+
+        results: List[Dict[str, Any]] = []
+        for request in request_list:
+            if not isinstance(request, dict):
+                continue
+            domain = request.get("domain")
+            code = request.get("code")
+            if not domain or not code:
+                continue
+            identifier = await self.ensure(
+                domain=domain,
+                code=str(code),
+                name=request.get("name"),
+                description=request.get("description"),
+                metadata=request.get("metadata"),
+            )
+            results.append({"domain": domain, "code": code, "id": identifier})
+
+        context.share(
+            self.name,
+            {"requests": request_list, "results": results},
+            overwrite=True,
+        )
+        return {"status": "ok", "operation": "lookup", "results": results}
+
+    async def ensure(
+        self,
+        *,
+        domain: str,
+        code: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        normalized = self.supabase.normalize_code(code)
+        cache_key = (domain, normalized)
+        if cache_key in self._memory:
+            return self._memory[cache_key]
+
+        identifier = await self.supabase.lookup(f"ref_code_{domain}", code=normalized)
+        if identifier:
+            self._memory[cache_key] = identifier
+            return identifier
+
+        identifier = await self.supabase.ensure_code(
+            domain=domain,
+            code=normalized,
+            name=name or code,
+            description=description,
+            metadata=metadata,
+        )
+        self._memory[cache_key] = identifier
+        return identifier
+
+    async def lookup(self, *, domain: str, code: str) -> Optional[str]:
+        normalized = self.supabase.normalize_code(code)
+        cache_key = (domain, normalized)
+        if cache_key in self._memory:
+            return self._memory[cache_key]
+        identifier = await self.supabase.lookup(f"ref_code_{domain}", code=normalized)
+        self._memory[cache_key] = identifier
+        return identifier
+
+
+__all__ = ["ReferenceCodeAgent"]

--- a/migration-tool/migration_tool/agents/verification.py
+++ b/migration-tool/migration_tool/agents/verification.py
@@ -1,0 +1,81 @@
+"""Agent supervising inserts and prompt adjustments."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..ai import PromptLibrary
+from ..schemas import AgentContext
+from ..telemetry import EventLog
+from .base import Agent
+
+
+class VerificationAgent(Agent):
+    """Monitor agent outcomes and tune prompts when issues repeat."""
+
+    name = "verification"
+    description = (
+        "Analyses routed fragments, tracks recurring Supabase errors, and adjusts"
+        " agent prompting guidance so data flows into the correct tables."
+    )
+
+    def __init__(
+        self,
+        telemetry: EventLog,
+        prompts: PromptLibrary,
+        *,
+        threshold: int = 3,
+    ) -> None:
+        super().__init__()
+        self.telemetry = telemetry
+        self.prompts = prompts
+        self.threshold = max(1, threshold)
+        self.expected_fields = []
+
+    async def handle(self, payload: Dict[str, Any], context: AgentContext) -> Dict[str, Any]:
+        fragments: List[Dict[str, Any]] = payload.get("fragments", [])
+        leftovers: Dict[str, Any] = payload.get("leftovers", {})
+        unhandled: Dict[str, Any] = payload.get("unhandled", {})
+        observed_agents = list(context.agent_events.keys())
+        adjustments: List[Dict[str, Any]] = []
+
+        for agent_name in observed_agents:
+            summary = self.prompts.error_summary(agent_name)
+            if summary["count"] >= self.threshold and summary["messages"]:
+                guidance = (
+                    "Focus on resolving these recurring validation issues: "
+                    + "; ".join(summary["messages"][-3:])
+                    + ". Ensure emitted rows respect Supabase relations and constraints."
+                )
+                self.prompts.set_guidance(agent_name, guidance)
+                adjustments.append(
+                    {
+                        "agent": agent_name,
+                        "guidance": guidance,
+                        "errors": summary,
+                    }
+                )
+                self.telemetry.record(
+                    "agent.verification.prompt_adjusted",
+                    {
+                        "agent": agent_name,
+                        "guidance": guidance,
+                        "errors": summary,
+                        "coordinator_id": context.coordinator_id,
+                    },
+                )
+                self.prompts.reset_errors(agent_name)
+
+        review = {
+            "status": "ok",
+            "observed_agents": observed_agents,
+            "fragments_reviewed": fragments,
+            "leftovers": leftovers,
+            "unhandled": unhandled,
+            "adjustments": adjustments,
+        }
+        context.share(self.name, review, overwrite=True)
+        return review
+
+
+__all__ = ["VerificationAgent"]

--- a/migration-tool/tests/test_ai_providers_schedule.py
+++ b/migration-tool/tests/test_ai_providers_schedule.py
@@ -1,6 +1,6 @@
 import pytest
 
-from migration_tool.ai import RuleBasedLLM
+from migration_tool.ai import PromptLibrary, RuleBasedLLM
 from migration_tool.agents.providers import ProviderAgent
 from migration_tool.agents.schedule import ScheduleAgent
 from migration_tool.schemas import AgentContext, ProviderTransformation, ScheduleTransformation
@@ -65,13 +65,19 @@ async def test_provider_agent_ai_transformation() -> None:
             }
         ]
     }
-    context = AgentContext(coordinator_id="test", source_payload=payload, object_id="reccZJ9INTTb7Mxtg")
+    context = AgentContext(
+        coordinator_id="test",
+        source_payload=payload,
+        object_id="reccZJ9INTTb7Mxtg",
+        prompt_library=PromptLibrary(),
+    )
 
     # Test AI transformation directly
     transformation = await llm.transform_fragment(
         agent_name="providers",
         payload=payload,
         response_model=ProviderTransformation,
+        context={},
     )
 
     assert isinstance(transformation, ProviderTransformation)
@@ -136,13 +142,19 @@ async def test_schedule_agent_ai_transformation() -> None:
             }
         ]
     }
-    context = AgentContext(coordinator_id="test", source_payload=payload, object_id="reccZJ9INTTb7Mxtg")
+    context = AgentContext(
+        coordinator_id="test",
+        source_payload=payload,
+        object_id="reccZJ9INTTb7Mxtg",
+        prompt_library=PromptLibrary(),
+    )
 
     # Test AI transformation directly
     transformation = await llm.transform_fragment(
         agent_name="schedule",
         payload=payload,
         response_model=ScheduleTransformation,
+        context={},
     )
 
     assert isinstance(transformation, ScheduleTransformation)

--- a/migration-tool/tests/test_ai_routing.py
+++ b/migration-tool/tests/test_ai_routing.py
@@ -1,7 +1,6 @@
 import pytest
-import pytest
 
-from migration_tool.ai import FieldRouter, RuleBasedLLM
+from migration_tool.ai import FieldRouter, PromptLibrary, RuleBasedLLM
 from migration_tool.agents.environment import EnvironmentAgent
 from migration_tool.agents.identity import IdentityAgent
 from migration_tool.agents.languages import LanguageAgent
@@ -10,6 +9,22 @@ from migration_tool.agents.pet_policy import PetPolicyAgent
 from migration_tool.schemas import AgentContext, AgentDescriptor
 from migration_tool.supabase_client import SupabaseService
 from migration_tool.telemetry import EventLog
+
+
+class ReferenceAgentStub:
+    async def ensure(
+        self,
+        *,
+        domain: str,
+        code: str,
+        name: str | None = None,
+        description: str | None = None,
+        metadata: dict | None = None,
+    ) -> str:
+        return f"{domain}:{code}"
+
+    async def lookup(self, *, domain: str, code: str) -> str | None:
+        return f"{domain}:{code}"
 
 
 @pytest.fixture
@@ -55,7 +70,12 @@ async def test_identity_agent_rule_based_transformation() -> None:
         "legacy_ids": ["LEGACY-1"],
         "description": "Bel établissement au centre-ville",
     }
-    context = AgentContext(coordinator_id="coord", source_payload=payload)
+    context = AgentContext(
+        coordinator_id="coord",
+        source_payload=payload,
+        prompt_library=PromptLibrary(),
+    )
+    context.attach_reference_agent(ReferenceAgentStub())
 
     result = await agent.handle(payload, context)
 
@@ -72,7 +92,13 @@ async def test_language_agent_rule_based_transformation() -> None:
     agent = LanguageAgent(supabase, telemetry, llm)
 
     payload = {"establishment_id": "OBJ1", "languages": ["Français", "Anglais"]}
-    context = AgentContext(coordinator_id="coord", source_payload=payload, object_id="OBJ1")
+    context = AgentContext(
+        coordinator_id="coord",
+        source_payload=payload,
+        object_id="OBJ1",
+        prompt_library=PromptLibrary(),
+    )
+    context.attach_reference_agent(ReferenceAgentStub())
 
     result = await agent.handle(payload, context)
 
@@ -89,7 +115,13 @@ async def test_payment_agent_rule_based_transformation() -> None:
     agent = PaymentMethodAgent(supabase, telemetry, llm)
 
     payload = {"establishment_id": "OBJ1", "payment_methods": ["Carte Bancaire", "Espèces"]}
-    context = AgentContext(coordinator_id="coord", source_payload=payload, object_id="OBJ1")
+    context = AgentContext(
+        coordinator_id="coord",
+        source_payload=payload,
+        object_id="OBJ1",
+        prompt_library=PromptLibrary(),
+    )
+    context.attach_reference_agent(ReferenceAgentStub())
 
     result = await agent.handle(payload, context)
 
@@ -106,7 +138,13 @@ async def test_environment_agent_rule_based_transformation() -> None:
     agent = EnvironmentAgent(supabase, telemetry, llm)
 
     payload = {"establishment_id": "OBJ1", "environment_tags": ["Village", "Milieu rural"]}
-    context = AgentContext(coordinator_id="coord", source_payload=payload, object_id="OBJ1")
+    context = AgentContext(
+        coordinator_id="coord",
+        source_payload=payload,
+        object_id="OBJ1",
+        prompt_library=PromptLibrary(),
+    )
+    context.attach_reference_agent(ReferenceAgentStub())
 
     result = await agent.handle(payload, context)
 
@@ -123,7 +161,12 @@ async def test_pet_policy_agent_rule_based_transformation() -> None:
     agent = PetPolicyAgent(supabase, telemetry, llm)
 
     payload = {"establishment_id": "OBJ1", "pets_allowed": "oui"}
-    context = AgentContext(coordinator_id="coord", source_payload=payload, object_id="OBJ1")
+    context = AgentContext(
+        coordinator_id="coord",
+        source_payload=payload,
+        object_id="OBJ1",
+        prompt_library=PromptLibrary(),
+    )
 
     result = await agent.handle(payload, context)
 

--- a/migration-tool/tests/test_coordinator_identity_flow.py
+++ b/migration-tool/tests/test_coordinator_identity_flow.py
@@ -1,10 +1,13 @@
 import pytest
 
+from migration_tool.ai import PromptLibrary
+
 from migration_tool.agents.base import Agent
 from migration_tool.agents.coordinator import Coordinator
 from migration_tool.schemas import FieldRoutingDecision, RawEstablishmentPayload
 from migration_tool.telemetry import EventLog
 from migration_tool.webhook import WebhookNotifier
+from migration_tool.agents.verification import VerificationAgent
 
 
 pytestmark = pytest.mark.anyio("asyncio")
@@ -31,10 +34,20 @@ class IdentityStub(Agent):
         self.generated_id = generated_id
         self.calls: list[dict[str, object]] = []
         self.expected_fields = ["establishment_name"]
+        self.shared: list[dict[str, object]] = []
 
     async def handle(self, payload, context):
         self.calls.append(payload)
         context.object_id = payload.get("establishment_id") or self.generated_id
+        context.share(
+            self.name,
+            {
+                "payload": payload,
+                "object_id": context.object_id,
+            },
+            overwrite=True,
+        )
+        self.shared.append(context.recall(self.name))
         return {"object_id": context.object_id}
 
 
@@ -46,11 +59,53 @@ class RecordingStub(Agent):
         self.expected_fields = []
         self.calls: list[dict[str, object]] = []
         self.object_ids: list[object] = []
+        self.recalled_identity: list[dict[str, object]] = []
+        self.shared_snapshots: list[dict[str, object]] = []
 
     async def handle(self, payload, context):
         self.calls.append(payload)
         self.object_ids.append(context.object_id)
+        self.recalled_identity.append(context.recall("identity"))
+        context.share(
+            self.name,
+            {
+                "payload": payload,
+                "object_id": context.object_id,
+            },
+            overwrite=True,
+        )
+        self.shared_snapshots.append(context.recall(self.name))
         return {"status": "ok", "agent": self.name}
+
+
+class ReferenceAgentStub(Agent):
+    name = "reference_codes"
+    description = "stub"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.expected_fields = ["requests"]
+        self.created: dict[tuple[str, str], str] = {}
+
+    async def handle(self, payload, context):  # pragma: no cover - unused in tests
+        return {"status": "ok"}
+
+    async def ensure(
+        self,
+        *,
+        domain: str,
+        code: str,
+        name: str | None = None,
+        description: str | None = None,
+        metadata: dict | None = None,
+    ) -> str:
+        key = (domain, code)
+        if key not in self.created:
+            self.created[key] = f"{domain}:{code}"
+        return self.created[key]
+
+    async def lookup(self, *, domain: str, code: str) -> str | None:
+        return self.created.get((domain, code))
 
 
 @pytest.fixture
@@ -82,6 +137,8 @@ async def test_identity_id_propagation_when_router_omits_section():
     router = StubRouter({"contact": {"phone": ["0262275287"]}})
     telemetry = EventLog()
     webhook = WebhookNotifier(url=None, telemetry=telemetry)
+    prompt_library = PromptLibrary()
+    verification_agent = VerificationAgent(telemetry, prompt_library)
 
     coordinator = Coordinator(
         identity_agent=identity_agent,
@@ -98,6 +155,9 @@ async def test_identity_id_propagation_when_router_omits_section():
         webhook=webhook,
         telemetry=telemetry,
         router=router,
+        verification_agent=verification_agent,
+        prompt_library=prompt_library,
+        reference_agent=ReferenceAgentStub(),
     )
 
     fragments, leftovers = await coordinator.handle(sample_payload)
@@ -105,7 +165,124 @@ async def test_identity_id_propagation_when_router_omits_section():
     assert leftovers == {}
     assert any(fragment.agent == "identity" for fragment in fragments)
     assert contact_agent.object_ids[0] == identity_agent.generated_id
-    assert contact_agent.calls[0]["establishment_id"] == identity_agent.generated_id
+    assert "establishment_id" not in contact_agent.calls[0]
     assert identity_agent.calls[0]["establishment_name"] == sample_payload.establishment_name
     assert identity_agent.calls[0]["legacy_ids"] == []
+
+
+@pytest.mark.anyio
+async def test_fallback_partition_routes_recognised_fields():
+    sample_payload = RawEstablishmentPayload.model_validate(
+        {
+            "name": "Chez Partition",
+            "category": "Restaurant",
+            "subcategory": "Brasserie",
+            "data": {
+                "phone": "0262275287",
+                "address_line1": "1 Rue du Port",
+                "city": "Saint-Denis",
+                "unknown": "keep-me",
+            },
+        }
+    )
+
+    identity_agent = IdentityStub()
+    location_agent = RecordingStub("location")
+    contact_agent = RecordingStub("contact")
+    router = StubRouter({})
+    telemetry = EventLog()
+    webhook = WebhookNotifier(url=None, telemetry=telemetry)
+    prompt_library = PromptLibrary()
+    verification_agent = VerificationAgent(telemetry, prompt_library)
+
+    coordinator = Coordinator(
+        identity_agent=identity_agent,
+        location_agent=location_agent,
+        contact_agent=contact_agent,
+        amenities_agent=RecordingStub("amenities"),
+        language_agent=RecordingStub("languages"),
+        payment_agent=RecordingStub("payments"),
+        environment_agent=RecordingStub("environment"),
+        pet_policy_agent=RecordingStub("pet_policy"),
+        media_agent=RecordingStub("media"),
+        provider_agent=RecordingStub("providers"),
+        schedule_agent=RecordingStub("schedule"),
+        webhook=webhook,
+        telemetry=telemetry,
+        router=router,
+        verification_agent=verification_agent,
+        prompt_library=prompt_library,
+        reference_agent=ReferenceAgentStub(),
+    )
+
+    fragments, leftovers = await coordinator.handle(sample_payload)
+
+    assert leftovers == {"unknown": "keep-me"}
+    assert location_agent.calls
+    assert location_agent.calls[0]["address_line1"] == "1 Rue du Port"
+    assert contact_agent.calls
+    assert contact_agent.calls[0]["phone"] == "0262275287"
+    processed_agents = {fragment.agent for fragment in fragments}
+    assert "location" in processed_agents
+    assert "contact" in processed_agents
+
+
+@pytest.mark.anyio
+async def test_agents_can_share_state_via_context():
+    sample_payload = RawEstablishmentPayload.model_validate(
+        {
+            "name": "Maison Partagée",
+            "establishment_name": "Maison Partagée",
+            "data": {
+                "address_line1": "5 Rue du Port",
+                "phone": ["0262000000"],
+            },
+        }
+    )
+
+    identity_agent = IdentityStub()
+    location_agent = RecordingStub("location")
+    contact_agent = RecordingStub("contact")
+    router = StubRouter(
+        {
+            "identity": {"establishment_name": "Maison Partagée"},
+            "location": {"address_line1": "5 Rue du Port"},
+            "contact": {"phone": ["0262000000"]},
+        }
+    )
+    telemetry = EventLog()
+    webhook = WebhookNotifier(url=None, telemetry=telemetry)
+    prompt_library = PromptLibrary()
+    verification_agent = VerificationAgent(telemetry, prompt_library)
+
+    coordinator = Coordinator(
+        identity_agent=identity_agent,
+        location_agent=location_agent,
+        contact_agent=contact_agent,
+        amenities_agent=RecordingStub("amenities"),
+        language_agent=RecordingStub("languages"),
+        payment_agent=RecordingStub("payments"),
+        environment_agent=RecordingStub("environment"),
+        pet_policy_agent=RecordingStub("pet_policy"),
+        media_agent=RecordingStub("media"),
+        provider_agent=RecordingStub("providers"),
+        schedule_agent=RecordingStub("schedule"),
+        webhook=webhook,
+        telemetry=telemetry,
+        router=router,
+        verification_agent=verification_agent,
+        prompt_library=prompt_library,
+        reference_agent=ReferenceAgentStub(),
+    )
+
+    fragments, leftovers = await coordinator.handle(sample_payload)
+
+    assert leftovers == {}
+    assert identity_agent.shared[-1]["object_id"] == identity_agent.generated_id
+    assert contact_agent.recalled_identity[-1]["object_id"] == identity_agent.generated_id
+    assert location_agent.recalled_identity[-1]["object_id"] == identity_agent.generated_id
+    assert contact_agent.shared_snapshots[-1]["payload"]["phone"] == ["0262000000"]
+    assert location_agent.shared_snapshots[-1]["payload"]["address_line1"] == "5 Rue du Port"
+    routed_agents = {fragment.agent for fragment in fragments}
+    assert routed_agents.issuperset({"identity", "contact", "location"})
 

--- a/migration-tool/tests/test_providers_schedule.py
+++ b/migration-tool/tests/test_providers_schedule.py
@@ -2,7 +2,7 @@ import types
 
 import pytest
 
-from migration_tool.ai import RuleBasedLLM
+from migration_tool.ai import PromptLibrary, RuleBasedLLM
 from migration_tool.agents.providers import ProviderAgent
 from migration_tool.agents.schedule import ScheduleAgent
 from migration_tool.schemas import AgentContext
@@ -45,7 +45,12 @@ async def test_provider_agent_processes_nested_payload() -> None:
             }
         ],
     }
-    context = AgentContext(coordinator_id="test", source_payload=payload, object_id="reccZJ9INTTb7Mxtg")
+    context = AgentContext(
+        coordinator_id="test",
+        source_payload=payload,
+        object_id="reccZJ9INTTb7Mxtg",
+        prompt_library=PromptLibrary(),
+    )
 
     result = await agent.handle(payload, context)
 
@@ -93,7 +98,12 @@ async def test_provider_agent_uses_returned_identifier() -> None:
             }
         ],
     }
-    context = AgentContext(coordinator_id="test", source_payload=payload, object_id="obj-1")
+    context = AgentContext(
+        coordinator_id="test",
+        source_payload=payload,
+        object_id="obj-1",
+        prompt_library=PromptLibrary(),
+    )
 
     result = await agent.handle(payload, context)
 
@@ -126,7 +136,12 @@ async def test_schedule_agent_processes_nested_payload() -> None:
             }
         ],
     }
-    context = AgentContext(coordinator_id="test", source_payload=payload, object_id="reccZJ9INTTb7Mxtg")
+    context = AgentContext(
+        coordinator_id="test",
+        source_payload=payload,
+        object_id="reccZJ9INTTb7Mxtg",
+        prompt_library=PromptLibrary(),
+    )
 
     result = await agent.handle(payload, context)
 


### PR DESCRIPTION
## Summary
- ensure the identity agent captures Supabase IDs reliably and records missing responses for investigation
- propagate the coordinator object ID through downstream agents, skipping and logging unresolved records while surfacing them to the verification report
- remove unsupported `extra` payloads from relation schemas so inserts only use existing columns

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d620645d1883279cca9787e4d305bf