### PR TITLE
Deploy-integrity CI gate + canonical-write authorization (P0.1, SP-1, SP-2)

### DIFF
--- a/.github/workflows/sql-fresh-apply.yml
+++ b/.github/workflows/sql-fresh-apply.yml
@@ -14,12 +14,12 @@ name: SQL fresh-apply gate
 on:
   push:
     paths:
-      - 'Base de donnée DLL et API/*.sql'
+      - 'Base de donnée DLL et API/**.sql'
       - 'supabase/config.toml'
       - '.github/workflows/sql-fresh-apply.yml'
   pull_request:
     paths:
-      - 'Base de donnée DLL et API/*.sql'
+      - 'Base de donnée DLL et API/**.sql'
       - '.github/workflows/sql-fresh-apply.yml'
   workflow_dispatch:
 

--- a/.github/workflows/sql-fresh-apply.yml
+++ b/.github/workflows/sql-fresh-apply.yml
@@ -1,0 +1,89 @@
+name: SQL fresh-apply gate
+
+# Proves that a BLANK database built from the canonical manifest
+# (docs/SQL_ROLLOUT_RUNBOOK.md → "Fresh Database — Complete Ordered Manifest")
+# applies cleanly, in order, with no error. This enforces the
+# "Deploy integrity (no PROD-only DDL)" invariant in CLAUDE.md: if a future
+# migration is applied only to live PROD and never folded into the manifest,
+# a fresh apply diverges and this gate goes red.
+#
+# Environment: the SQL files target Supabase (auth/storage schemas, auth.uid(),
+# roles anon/authenticated/service_role), so the gate boots a real Supabase
+# local database via the CLI rather than a bare Postgres container.
+
+on:
+  push:
+    paths:
+      - 'Base de donnée DLL et API/*.sql'
+      - 'supabase/config.toml'
+      - '.github/workflows/sql-fresh-apply.yml'
+  pull_request:
+    paths:
+      - 'Base de donnée DLL et API/*.sql'
+      - '.github/workflows/sql-fresh-apply.yml'
+  workflow_dispatch:
+
+jobs:
+  fresh-apply:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.78.1
+
+      - name: Ensure psql is available
+        run: psql --version || (sudo apt-get update && sudo apt-get install -y postgresql-client)
+
+      - name: Start Supabase local database
+        # Boots the Supabase-flavoured Postgres (DB image provides the auth/storage
+        # schemas, the anon/authenticated/service_role roles, and the extensions the
+        # manifest depends on). config.toml pins major_version 17 to match PROD.
+        run: supabase start
+
+      - name: Apply the canonical fresh-install manifest (aborts on first error)
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: psql "$DB_URL" -v ON_ERROR_STOP=1 -f "Base de donnée DLL et API/ci_fresh_apply.sql"
+
+      - name: Smoke — assert the manifest produced the expected schema
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          psql "$DB_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          DO $$
+          BEGIN
+            ASSERT (SELECT count(*) FROM information_schema.columns WHERE table_name='tag_link' AND column_name='position') = 1,
+              'tag_link.position missing (migration_tag_link_position.sql not applied)';
+            ASSERT (SELECT count(*) FROM information_schema.columns WHERE table_name='object_room_type' AND column_name='room_type_id') = 1,
+              'object_room_type.room_type_id missing (migration_room_type_ref.sql not applied)';
+            ASSERT (SELECT count(*) FROM information_schema.tables WHERE table_name='ref_sustainability_action_group') = 1,
+              'ref_sustainability_action_group missing (migration_sustainability_v5.sql not applied)';
+            ASSERT (SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+                    WHERE n.nspname='api' AND p.proname='save_object_workspace_tags') = 1,
+              'api.save_object_workspace_tags missing (object_workspace_gap_rpcs.sql not applied)';
+            ASSERT (SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+                    WHERE n.nspname='internal' AND p.proname='workspace_assert_can_write_object') = 1,
+              'internal.workspace_assert_can_write_object missing (object_workspace_safe_write_rpcs.sql not applied)';
+            ASSERT (SELECT count(*) FROM storage.buckets WHERE id='media') = 1,
+              'media storage bucket missing (media_bucket.sql not applied)';
+            RAISE NOTICE 'Smoke checks passed: manifest reproduced the expected schema.';
+          END$$;
+          SQL
+
+      - name: SP-1 structural assertions (canonical-write authorization)
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: psql "$DB_URL" -v ON_ERROR_STOP=1 -f "Base de donnée DLL et API/tests/test_sp1_canonical_write_auth.sql"
+
+      - name: SP-2 behavioral test (permission convention + status guard + team notes)
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: psql "$DB_URL" -v ON_ERROR_STOP=1 -f "Base de donnée DLL et API/tests/test_sp2_permission_behavior.sql"
+
+      - name: Stop Supabase
+        if: always()
+        run: supabase stop

--- a/Base de donnée DLL et API/README.md
+++ b/Base de donnée DLL et API/README.md
@@ -8,13 +8,28 @@ Ce dossier contient le schema SQL principal, les fonctions RPC exposees dans le 
 
 ```text
 Base de donnee DLL et API/
-├── schema_unified.sql
-├── api_views_functions.sql
-├── rls_policies.sql
-├── ui_whitelabel_branding.sql
-├── seeds_data.sql
-├── test_performance.sql
-├── maintenance.sql
+├── Fresh install core
+│   ├── schema_unified.sql
+│   ├── migration_sustainability_v5.sql
+│   ├── migration_room_type_ref.sql
+│   ├── migration_tag_link_position.sql
+│   ├── api_views_functions.sql
+│   ├── rls_policies.sql
+│   ├── object_workspace_safe_write_rpcs.sql
+│   ├── object_workspace_gap_rpcs.sql
+│   ├── ui_whitelabel_branding.sql
+│   ├── media_bucket.sql
+│   └── seeds_data.sql
+├── Post-seed / post-import fixups
+│   ├── migration_legal_siret_canonical.sql
+│   └── migration_object_location_address1_dedupe.sql
+├── Maintenance and benchmarks
+│   ├── maintenance.sql
+│   └── test_performance.sql
+├── Upgrade-only patch
+│   └── branding_admin_profile_role_patch.sql
+├── Local / pilot-only inserts
+│   └── lot1_pilot_inserts.sql
 └── README.md
 ```
 
@@ -32,6 +47,7 @@ CREATE EXTENSION IF NOT EXISTS "postgis";
 CREATE EXTENSION IF NOT EXISTS "unaccent" WITH SCHEMA extensions;
 CREATE EXTENSION IF NOT EXISTS "pg_trgm";
 CREATE EXTENSION IF NOT EXISTS btree_gist;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 ```
 
 Optionnel (uniquement si vous planifiez des taches programmees SQL):
@@ -44,17 +60,38 @@ CREATE EXTENSION IF NOT EXISTS pg_cron;
 -- 1) Schema
 \i schema_unified.sql
 
--- 2) Fonctions API
+-- 2) Migrations DDL (AVANT api/seeds ; ajoutent colonnes/tables requises)
+\i migration_sustainability_v5.sql
+\i migration_room_type_ref.sql
+\i migration_tag_link_position.sql
+
+-- 3) Fonctions API
 \i api_views_functions.sql
 
--- 3) Politiques RLS
+-- 4) Politiques RLS (definit api.is_object_owner)
 \i rls_policies.sql
 
--- 4) Branding UI et parametres white-label
+-- 5) RPC d'ecriture editeur (schema internal + sections restantes)
+\i object_workspace_safe_write_rpcs.sql
+\i object_workspace_gap_rpcs.sql
+
+-- 5b) SP-1 autorisation d'ecriture canonique (apres les RPC workspace, avant le branding)
+\i migration_permission_write_paths.sql
+
+-- 6) Branding UI white-label (fichier complet pour une install neuve)
 \i ui_whitelabel_branding.sql
 
--- 5) Donnees de seed (optionnel)
+-- 7) Bucket de stockage media
+\i media_bucket.sql
+
+-- 8) Donnees de seed (necessite migration_sustainability_v5)
 \i seeds_data.sql
+
+-- 9) Correctifs de donnees APRES seeds (no-op sur base neuve)
+\i migration_legal_siret_canonical.sql
+\i migration_object_location_address1_dedupe.sql
+
+-- Ordre complet + refresh MV + rollback : voir docs/SQL_ROLLOUT_RUNBOOK.md
 ```
 
 ## Fonctions API principales (existantes)
@@ -223,18 +260,18 @@ Le modele cible impose une unicite stricte sur `ref_code(domain, code)`.
 \i maintenance.sql
 ```
 
-Recommandation de rafraichissement `mv_filtered_objects`:
+Recommandation de rafraichissement `internal.mv_filtered_objects`:
 
 ```sql
 -- Toutes les 5 minutes (SLA listing/filtrage)
 SELECT cron.schedule(
   'refresh-mv-filtered-objects',
   '*/5 * * * *',
-  $$REFRESH MATERIALIZED VIEW CONCURRENTLY mv_filtered_objects$$
+  $$REFRESH MATERIALIZED VIEW CONCURRENTLY internal.mv_filtered_objects$$
 );
 ```
 
-Points de stale possibles pour `mv_filtered_objects`:
+Points de stale possibles pour `internal.mv_filtered_objects`:
 - changements de localisation principale (`object_location`)
 - transitions de statut editorial (`object.status`)
 - changements de nom / index de recherche (`object.name*`)

--- a/Base de donnée DLL et API/ci_fresh_apply.sql
+++ b/Base de donnée DLL et API/ci_fresh_apply.sql
@@ -1,0 +1,68 @@
+-- ci_fresh_apply.sql
+-- Executable form of the canonical fresh-install manifest documented in
+-- docs/SQL_ROLLOUT_RUNBOOK.md ("Fresh Database — Complete Ordered Manifest").
+-- Applies every schema file to a BLANK database in dependency order and ABORTS
+-- on the first error (\set ON_ERROR_STOP on).
+--
+-- Used by .github/workflows/sql-fresh-apply.yml — the CI gate that enforces the
+-- "Deploy integrity (no PROD-only DDL)" invariant in CLAUDE.md. Also runnable
+-- locally against a `supabase start` database:
+--   psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" \
+--     -v ON_ERROR_STOP=1 -f "Base de donnée DLL et API/ci_fresh_apply.sql"
+--
+-- REQUIRES a Supabase-flavoured Postgres: the files reference the `auth` and
+-- `storage` schemas, auth.uid()/auth.role(), and the roles anon / authenticated
+-- / service_role. A vanilla Postgres will fail at the RLS and media_bucket steps.
+--
+-- Paths use \ir (include relative to THIS file), so the current working
+-- directory does not matter.
+
+\set ON_ERROR_STOP on
+
+-- 0. Extensions. pg_cron is intentionally OMITTED: schema_unified.sql references
+--    it only in comments (freshness-strategy docs), never as executed DDL.
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS postgis;
+CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA extensions;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+\echo '== 1/13  schema_unified.sql =='
+\ir schema_unified.sql
+\echo '== 2/13  migration_sustainability_v5.sql  (prereq for V5 seeds) =='
+\ir migration_sustainability_v5.sql
+\echo '== 3/13  migration_room_type_ref.sql =='
+\ir migration_room_type_ref.sql
+\echo '== 4/13  migration_tag_link_position.sql =='
+\ir migration_tag_link_position.sql
+\echo '== 5/13  api_views_functions.sql =='
+\ir api_views_functions.sql
+\echo '== 6/13  rls_policies.sql  (defines api.is_object_owner) =='
+\ir rls_policies.sql
+\echo '== 7/13  object_workspace_safe_write_rpcs.sql  (schema internal + write gate) =='
+\ir object_workspace_safe_write_rpcs.sql
+\echo '== 8/13  object_workspace_gap_rpcs.sql =='
+\ir object_workspace_gap_rpcs.sql
+\echo '== 8b     migration_permission_write_paths.sql  (SP-1 canonical-write auth; after RLS + workspace RPCs) =='
+\ir migration_permission_write_paths.sql
+\echo '== 9/13  ui_whitelabel_branding.sql  (defines api.is_platform_admin) =='
+\ir ui_whitelabel_branding.sql
+\echo '== 10/13 media_bucket.sql  (storage bucket + RESTRICTIVE write RLS) =='
+\ir media_bucket.sql
+\echo '== 11/13 seeds_data.sql  (needs ref_sustainability_action_group from step 2) =='
+\ir seeds_data.sql
+\echo '== 12/13 migration_legal_siret_canonical.sql  (data fixup; AFTER seeds) =='
+\ir migration_legal_siret_canonical.sql
+\echo '== 13/13 migration_object_location_address1_dedupe.sql  (post-import hygiene; no-op fresh) =='
+\ir migration_object_location_address1_dedupe.sql
+
+-- Materialized views are created WITH DATA in schema_unified.sql; refresh
+-- NON-concurrently here so this also works on a never-yet-populated MV.
+-- (Production scheduling uses REFRESH ... CONCURRENTLY via pg_cron — see runbook.)
+\echo '== MV refresh (non-concurrent) =='
+REFRESH MATERIALIZED VIEW internal.mv_ref_data_json;
+REFRESH MATERIALIZED VIEW internal.mv_filtered_objects;
+
+\echo '== Fresh apply complete =='

--- a/Base de donnée DLL et API/migration_legal_siret_canonical.sql
+++ b/Base de donnée DLL et API/migration_legal_siret_canonical.sql
@@ -27,16 +27,18 @@ SET
     ELSE E'\nAuto-revoked: redundant with active siret (canonical identity).'
   END,
   updated_at = NOW()
-FROM ref_legal_type rlt_siren
-JOIN object_legal ol_siret
-  ON ol_siret.object_id = ol_siren.object_id
- AND ol_siret.status = 'active'
-JOIN ref_legal_type rlt_siret
-  ON rlt_siret.id = ol_siret.type_id
- AND rlt_siret.code = 'siret'
+FROM ref_legal_type rlt_siren,
+     object_legal ol_siret
+     JOIN ref_legal_type rlt_siret
+       ON rlt_siret.id = ol_siret.type_id
+      AND rlt_siret.code = 'siret'
 WHERE ol_siren.type_id = rlt_siren.id
   AND rlt_siren.code = 'siren'
   AND ol_siren.status = 'active'
+  -- ol_siret correlation moved out of FROM: the UPDATE target (ol_siren) may not be
+  -- referenced inside a FROM-clause JOIN (Postgres). Same result, valid placement.
+  AND ol_siret.object_id = ol_siren.object_id
+  AND ol_siret.status = 'active'
   AND NULLIF(
     TRIM(
       COALESCE(

--- a/Base de donnée DLL et API/migration_permission_write_paths.sql
+++ b/Base de donnée DLL et API/migration_permission_write_paths.sql
@@ -1,0 +1,224 @@
+-- migration_permission_write_paths.sql
+-- SP-1 of P0.2 — canonical-write authorization wired into the editor write paths.
+-- Substitutes the legacy `api.is_object_owner(...)` predicate with the ADDITIVE
+-- `api.user_can_write_object_canonical(...)` (= is_object_owner OR user_can_write_canonical)
+-- across the workspace gate + the 23 object/child-table write policies, and adds a
+-- status-change guard so edit_canonical_when_publisher != publish_object.
+--
+-- PREREQUISITES: schema_unified.sql, rls_policies.sql (defines is_object_owner,
+--   user_can_write_canonical, user_can_publish_object, is_platform_superuser),
+--   object_workspace_safe_write_rpcs.sql (the gate). APPLY AFTER object_workspace_gap_rpcs.sql.
+-- IDEMPOTENT: CREATE OR REPLACE + DROP POLICY/TRIGGER IF EXISTS. TRANSACTION-WRAPPED.
+-- REVERSIBLE: see docs/superpowers/specs/2026-06-02-sp1-canonical-write-auth-design.md §7.
+-- INERT until SP-2 grants permissions (0 grants on live today); additive => no regression.
+
+BEGIN;
+
+-- 1) Single source of truth for canonical-write authorization (additive OR).
+CREATE OR REPLACE FUNCTION api.user_can_write_object_canonical(p_object_id text)
+RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, api, auth
+AS $fn$
+  SELECT api.is_object_owner(p_object_id)            -- legacy actor-owner + service_role/admin + platform superuser
+      OR api.user_can_write_canonical(p_object_id);  -- publisher ORG member holding edit_canonical_when_publisher
+$fn$;
+REVOKE EXECUTE ON FUNCTION api.user_can_write_object_canonical(text) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION api.user_can_write_object_canonical(text) TO authenticated, service_role;
+
+-- 2) Workspace gate (was: is_object_owner only).
+CREATE OR REPLACE FUNCTION internal.workspace_assert_can_write_object(p_object_id text)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, api, internal, auth
+AS $fn$
+BEGIN
+  IF p_object_id IS NULL OR btrim(p_object_id) = '' THEN
+    RAISE EXCEPTION 'object_id is required' USING ERRCODE = '22023';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.object WHERE id = p_object_id) THEN
+    RAISE EXCEPTION 'Unknown object_id: %', p_object_id USING ERRCODE = 'P0002';
+  END IF;
+  IF NOT api.user_can_write_object_canonical(p_object_id) THEN
+    RAISE EXCEPTION 'Current user cannot write object %', p_object_id USING ERRCODE = '42501';
+  END IF;
+END;
+$fn$;
+
+-- 3) object UPDATE / DELETE: created_by OR canonical writer.
+DROP POLICY IF EXISTS "owner_update_object" ON object;
+CREATE POLICY "owner_update_object" ON object
+  FOR UPDATE
+  USING      (auth.uid() = created_by OR api.user_can_write_object_canonical(id))
+  WITH CHECK (auth.uid() = created_by OR api.user_can_write_object_canonical(id));
+
+DROP POLICY IF EXISTS "owner_delete_object" ON object;
+CREATE POLICY "owner_delete_object" ON object
+  FOR DELETE
+  USING (auth.uid() = created_by OR api.user_can_write_object_canonical(id));
+
+-- 4) Simple child-table write policies (FOR ALL USING object_id).
+DROP POLICY IF EXISTS "owner_write_location" ON object_location;
+CREATE POLICY "owner_write_location" ON object_location
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_write_place" ON object_place;
+CREATE POLICY "owner_write_place" ON object_place
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_write_contact" ON contact_channel;
+CREATE POLICY "owner_write_contact" ON contact_channel
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_write_media" ON media;
+CREATE POLICY "owner_write_media" ON media
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_write_legal" ON object_legal;
+CREATE POLICY "owner_write_legal" ON object_legal
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_write_discount" ON object_discount;
+CREATE POLICY "owner_write_discount" ON object_discount
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_write_group_policy" ON object_group_policy;
+CREATE POLICY "owner_write_group_policy" ON object_group_policy
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_price_write" ON object_price;
+CREATE POLICY "owner_price_write" ON object_price
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_menu_write" ON object_menu;
+CREATE POLICY "owner_menu_write" ON object_menu
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_meeting_room_write" ON object_meeting_room;
+CREATE POLICY "owner_meeting_room_write" ON object_meeting_room
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_pet_policy_write" ON object_pet_policy;
+CREATE POLICY "owner_pet_policy_write" ON object_pet_policy
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_fma_occurrence_write" ON object_fma_occurrence;
+CREATE POLICY "owner_fma_occurrence_write" ON object_fma_occurrence
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+-- 5) object_description carve-out: new canonical path is restricted to canonical rows
+--    (org_object_id IS NULL); per-org overlays stay the sole domain of rpc_write_org_description (§20).
+DROP POLICY IF EXISTS "owner_write_description" ON object_description;
+CREATE POLICY "owner_write_description" ON object_description
+  FOR ALL USING (
+    api.is_object_owner(object_id)
+    OR (api.user_can_write_canonical(object_id) AND org_object_id IS NULL)
+  );
+
+-- 6) Nested child policies (EXISTS via parent — substitute the inner is_object_owner).
+DROP POLICY IF EXISTS "owner_price_period_write" ON object_price_period;
+CREATE POLICY "owner_price_period_write" ON object_price_period
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_price op
+            WHERE op.id = object_price_period.price_id
+              AND api.user_can_write_object_canonical(op.object_id))
+  );
+
+DROP POLICY IF EXISTS "owner_menu_item_write" ON object_menu_item;
+CREATE POLICY "owner_menu_item_write" ON object_menu_item
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_menu om
+            WHERE om.id = object_menu_item.menu_id
+              AND api.user_can_write_object_canonical(om.object_id))
+  );
+
+DROP POLICY IF EXISTS "owner_menu_item_dietary_write" ON object_menu_item_dietary_tag;
+CREATE POLICY "owner_menu_item_dietary_write" ON object_menu_item_dietary_tag
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_menu_item omi
+            JOIN object_menu om ON om.id = omi.menu_id
+            WHERE omi.id = object_menu_item_dietary_tag.menu_item_id
+              AND api.user_can_write_object_canonical(om.object_id))
+  );
+
+DROP POLICY IF EXISTS "owner_menu_item_allergen_write" ON object_menu_item_allergen;
+CREATE POLICY "owner_menu_item_allergen_write" ON object_menu_item_allergen
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_menu_item omi
+            JOIN object_menu om ON om.id = omi.menu_id
+            WHERE omi.id = object_menu_item_allergen.menu_item_id
+              AND api.user_can_write_object_canonical(om.object_id))
+  );
+
+DROP POLICY IF EXISTS "owner_menu_item_cuisine_write" ON object_menu_item_cuisine_type;
+CREATE POLICY "owner_menu_item_cuisine_write" ON object_menu_item_cuisine_type
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_menu_item omi
+            JOIN object_menu om ON om.id = omi.menu_id
+            WHERE omi.id = object_menu_item_cuisine_type.menu_item_id
+              AND api.user_can_write_object_canonical(om.object_id))
+  );
+
+DROP POLICY IF EXISTS "owner_menu_item_media_write" ON object_menu_item_media;
+CREATE POLICY "owner_menu_item_media_write" ON object_menu_item_media
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_menu_item omi
+            JOIN object_menu om ON om.id = omi.menu_id
+            WHERE omi.id = object_menu_item_media.menu_item_id
+              AND api.user_can_write_object_canonical(om.object_id))
+  );
+
+DROP POLICY IF EXISTS "owner_meeting_room_equipment_write" ON meeting_room_equipment;
+CREATE POLICY "owner_meeting_room_equipment_write" ON meeting_room_equipment
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_meeting_room omr
+            WHERE omr.id = meeting_room_equipment.room_id
+              AND api.user_can_write_object_canonical(omr.object_id))
+  );
+
+DROP POLICY IF EXISTS "owner_iti_stage_media_write" ON object_iti_stage_media;
+CREATE POLICY "owner_iti_stage_media_write" ON object_iti_stage_media
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_iti_stage ois
+            WHERE ois.id = object_iti_stage_media.stage_id
+              AND api.user_can_write_object_canonical(ois.object_id))
+  );
+
+-- 7) object_membership (keeps the admin branch; COALESCE handles ORG-scoped memberships).
+DROP POLICY IF EXISTS "owner_object_membership_write" ON object_membership;
+CREATE POLICY "owner_object_membership_write" ON object_membership
+  FOR ALL USING (
+    auth.role() IN ('service_role','admin')
+    OR api.user_can_write_object_canonical(COALESCE(object_id, org_object_id))
+  );
+
+-- 8) Status guard: status changes require publish_object (rpc_publish_object), not edit_canonical.
+--    service_role/admin and platform superuser are exempt. rpc_publish_object verifies the
+--    caller's publish right before its UPDATE, so the trigger re-check passes for it
+--    (auth.uid() is preserved under SECURITY DEFINER). Fires only when `status` is in the SET list.
+CREATE OR REPLACE FUNCTION api.guard_object_status_change()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, api, auth
+AS $fn$
+BEGIN
+  IF NEW.status IS DISTINCT FROM OLD.status
+     AND auth.role() NOT IN ('service_role','admin')
+     AND NOT api.is_platform_superuser()
+     AND NOT api.user_can_publish_object(NEW.id)
+  THEN
+    RAISE EXCEPTION
+      'Object status changes require the publish_object permission (use api.rpc_publish_object); edit_canonical_when_publisher does not grant publishing'
+      USING ERRCODE = '42501';
+  END IF;
+  RETURN NEW;
+END;
+$fn$;
+REVOKE EXECUTE ON FUNCTION api.guard_object_status_change() FROM PUBLIC, anon;
+
+DROP TRIGGER IF EXISTS trg_guard_object_status_change ON object;
+CREATE TRIGGER trg_guard_object_status_change
+  BEFORE UPDATE OF status ON object
+  FOR EACH ROW EXECUTE FUNCTION api.guard_object_status_change();
+
+COMMIT;

--- a/Base de donnée DLL et API/migration_permission_write_paths.sql
+++ b/Base de donnée DLL et API/migration_permission_write_paths.sql
@@ -221,4 +221,14 @@ CREATE TRIGGER trg_guard_object_status_change
   BEFORE UPDATE OF status ON object
   FOR EACH ROW EXECUTE FUNCTION api.guard_object_status_change();
 
+-- 9) Versioning trigger must run as OWNER so it can write the admin-only object_version
+--    history table on behalf of a permission-holding (non-superuser) editor. object_version
+--    RLS allows only service_role/admin; the trigger function save_object_version was
+--    SECURITY INVOKER, so ANY authenticated `UPDATE object` failed with
+--    "new row violates row-level security policy for table object_version" — which would
+--    block every multi-role canonical write this migration is meant to enable. The sibling
+--    audit trigger (log_row_changes) is already SECURITY DEFINER; save_object_version already
+--    pins SET search_path, so DEFINER is safe. (Found by the SP-2 behavioral test via the CI gate.)
+ALTER FUNCTION public.save_object_version() SECURITY DEFINER;
+
 COMMIT;

--- a/Base de donnée DLL et API/rls_policies.sql
+++ b/Base de donnée DLL et API/rls_policies.sql
@@ -191,6 +191,17 @@ AS $$
     OR EXISTS (SELECT 1 FROM external_published);
 $$;
 
+-- ── Forward declarations (fresh-apply ordering fix) ─────────────────────────
+-- is_object_owner (below) and current_user_can_edit_objects (further below) are
+-- SQL-language functions whose bodies are validated at CREATE time, and they call
+-- api.is_platform_superuser() and api.user_has_permission(), which this file otherwise
+-- defines much later (~L1765 and ~L2495). On a blank DB that ordering fails with
+-- "function does not exist". Declare minimal stubs here so the early functions compile;
+-- the canonical definitions later in THIS file replace them via CREATE OR REPLACE
+-- (same signatures), so runtime behaviour is unchanged. (Found by the SQL fresh-apply CI gate.)
+CREATE OR REPLACE FUNCTION api.is_platform_superuser() RETURNS boolean LANGUAGE sql STABLE AS $$ SELECT false $$;
+CREATE OR REPLACE FUNCTION api.user_has_permission(p_permission_code text) RETURNS boolean LANGUAGE sql STABLE AS $$ SELECT false $$;
+
 -- Vérifie si l'utilisateur est propriétaire (owner) de l'objet
 -- via un rôle actor_object_role lié à son email dans actor_channel
 CREATE OR REPLACE FUNCTION api.is_object_owner(p_object_id text)

--- a/Base de donnée DLL et API/tests/test_sp1_canonical_write_auth.sql
+++ b/Base de donnée DLL et API/tests/test_sp1_canonical_write_auth.sql
@@ -1,0 +1,60 @@
+-- test_sp1_canonical_write_auth.sql
+-- SP-1 structural assertions. Run AFTER the base manifest + migration_permission_write_paths.sql.
+-- Deterministic (catalog-only): asserts the helper + status trigger exist, the workspace gate
+-- is wired to the helper, and every targeted write policy now references the helper.
+-- Behavioral (granted-contributor can write / cannot publish) tests are SP-2.
+\set ON_ERROR_STOP on
+DO $$
+DECLARE
+  v_missing text[] := ARRAY[]::text[];
+  v_legacy  text[];
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+                 WHERE n.nspname='api' AND p.proname='user_can_write_object_canonical') THEN
+    v_missing := v_missing || 'api.user_can_write_object_canonical';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger
+                 WHERE tgname='trg_guard_object_status_change' AND NOT tgisinternal) THEN
+    v_missing := v_missing || 'trg_guard_object_status_change';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+                 WHERE n.nspname='internal' AND p.proname='workspace_assert_can_write_object'
+                   AND pg_get_functiondef(p.oid) LIKE '%user_can_write_object_canonical%') THEN
+    v_missing := v_missing || 'workspace gate not wired to helper';
+  END IF;
+
+  IF array_length(v_missing, 1) > 0 THEN
+    RAISE EXCEPTION 'SP-1 objects missing: %', array_to_string(v_missing, ', ');
+  END IF;
+
+  -- Every targeted write policy must reference the helper in its USING (qual).
+  -- object_description is intentionally excluded (carve-out keeps is_object_owner OR
+  -- (user_can_write_canonical AND org_object_id IS NULL)).
+  SELECT array_agg(policyname) INTO v_legacy
+  FROM pg_policies
+  WHERE schemaname='public'
+    AND policyname IN (
+      'owner_write_location','owner_write_place','owner_write_contact','owner_write_media',
+      'owner_write_legal','owner_write_discount','owner_write_group_policy',
+      'owner_price_write','owner_price_period_write','owner_menu_write','owner_menu_item_write',
+      'owner_menu_item_dietary_write','owner_menu_item_allergen_write','owner_menu_item_cuisine_write',
+      'owner_menu_item_media_write','owner_meeting_room_write','owner_meeting_room_equipment_write',
+      'owner_pet_policy_write','owner_fma_occurrence_write','owner_iti_stage_media_write',
+      'owner_object_membership_write','owner_update_object','owner_delete_object'
+    )
+    AND COALESCE(qual,'') NOT LIKE '%user_can_write_object_canonical%';
+  IF v_legacy IS NOT NULL THEN
+    RAISE EXCEPTION 'Policies still on legacy predicate (not wired to helper): %', array_to_string(v_legacy, ', ');
+  END IF;
+
+  -- object_description carve-out: must reference BOTH the canonical helper and the overlay guard.
+  IF NOT EXISTS (SELECT 1 FROM pg_policies
+                 WHERE schemaname='public' AND policyname='owner_write_description'
+                   AND qual LIKE '%user_can_write_canonical%' AND qual LIKE '%org_object_id%') THEN
+    RAISE EXCEPTION 'owner_write_description carve-out (canonical + org_object_id IS NULL) not in place';
+  END IF;
+
+  RAISE NOTICE 'SP-1 structural assertions passed.';
+END$$;

--- a/Base de donnée DLL et API/tests/test_sp2_permission_behavior.sql
+++ b/Base de donnée DLL et API/tests/test_sp2_permission_behavior.sql
@@ -33,9 +33,17 @@ BEGIN
     (v_obj, 'HOT', 'SP2 Test Hotel');
   INSERT INTO object_org_link (object_id, org_object_id, role_id) VALUES (v_obj, v_org, v_pub_role);
 
-  INSERT INTO auth.users (id) VALUES (v_view_uid), (v_contrib_uid), (v_editor_uid);
+  -- auth.users has trigger `on_auth_user_created_app_user_profile` which AUTO-CREATES the
+  -- app_user_profile row. So we insert the users (with unique emails), then UPSERT the profile
+  -- role to a non-superuser value — ON CONFLICT absorbs the trigger-created rows (verified:
+  -- is_platform_superuser() is only owner/super_admin/service_role, so 'tourism_agent' is non-super).
+  INSERT INTO auth.users (id, email) VALUES
+    (v_view_uid,    'sp2_viewer@test.local'),
+    (v_contrib_uid, 'sp2_contributor@test.local'),
+    (v_editor_uid,  'sp2_editor@test.local');
   INSERT INTO app_user_profile (id, role) VALUES
-    (v_view_uid, 'tourism_agent'), (v_contrib_uid, 'tourism_agent'), (v_editor_uid, 'tourism_agent');
+    (v_view_uid, 'tourism_agent'), (v_contrib_uid, 'tourism_agent'), (v_editor_uid, 'tourism_agent')
+  ON CONFLICT (id) DO UPDATE SET role = EXCLUDED.role;
 
   INSERT INTO user_org_membership (user_id, org_object_id, is_active) VALUES (v_view_uid,    v_org, TRUE) RETURNING id INTO v_m_view;
   INSERT INTO user_org_membership (user_id, org_object_id, is_active) VALUES (v_contrib_uid, v_org, TRUE) RETURNING id INTO v_m_contrib;

--- a/Base de donnée DLL et API/tests/test_sp2_permission_behavior.sql
+++ b/Base de donnée DLL et API/tests/test_sp2_permission_behavior.sql
@@ -1,0 +1,130 @@
+-- test_sp2_permission_behavior.sql
+-- SP-2 behavioral test: proves SP-1 canonical-write authorization + status guard + the
+-- membership-based team-note rule, end-to-end, against a seeded multi-user fixture.
+-- Self-contained + transactional: everything is ROLLBACK'd, nothing persists.
+-- Run AFTER the full manifest INCLUDING migration_permission_write_paths.sql (SP-1).
+-- Against a DB without SP-1, it fails fast (api.user_can_write_object_canonical missing) — that is the red state.
+--
+-- WATCH-POINTS (may need a tweak on first CI run; the assertions' intent is stable):
+--   * auth.users minimal insert (only id is NOT NULL/no-default on this DB);
+--   * app_user_profile.role value 'tourism_agent' must be a non-superuser role;
+--   * plpgsql SET LOCAL ROLE + subtransaction exception mechanics;
+--   * object id format if a CHECK constraint exists (explicit test ids used).
+\set ON_ERROR_STOP on
+BEGIN;
+
+DO $$
+DECLARE
+  v_org         text := 'ORGRUN9999999991';
+  v_obj         text := 'HOTRUN9999999991';
+  v_pub_role    uuid;
+  v_view_uid    uuid := '00000000-0000-4000-a000-0000000000a1';
+  v_contrib_uid uuid := '00000000-0000-4000-a000-0000000000a2';
+  v_editor_uid  uuid := '00000000-0000-4000-a000-0000000000a3';
+  v_m_view uuid; v_m_contrib uuid; v_m_editor uuid;
+  v_note_view uuid;
+  v_rc integer;
+BEGIN
+  -- ---------- Fixture (as postgres; RLS bypassed for setup) ----------
+  SELECT id INTO v_pub_role FROM ref_org_role WHERE code = 'publisher';
+
+  INSERT INTO object (id, object_type, name) VALUES
+    (v_org, 'ORG', 'SP2 Test Org'),
+    (v_obj, 'HOT', 'SP2 Test Hotel');
+  INSERT INTO object_org_link (object_id, org_object_id, role_id) VALUES (v_obj, v_org, v_pub_role);
+
+  INSERT INTO auth.users (id) VALUES (v_view_uid), (v_contrib_uid), (v_editor_uid);
+  INSERT INTO app_user_profile (id, role) VALUES
+    (v_view_uid, 'tourism_agent'), (v_contrib_uid, 'tourism_agent'), (v_editor_uid, 'tourism_agent');
+
+  INSERT INTO user_org_membership (user_id, org_object_id, is_active) VALUES (v_view_uid,    v_org, TRUE) RETURNING id INTO v_m_view;
+  INSERT INTO user_org_membership (user_id, org_object_id, is_active) VALUES (v_contrib_uid, v_org, TRUE) RETURNING id INTO v_m_contrib;
+  INSERT INTO user_org_membership (user_id, org_object_id, is_active) VALUES (v_editor_uid,  v_org, TRUE) RETURNING id INTO v_m_editor;
+
+  INSERT INTO user_org_business_role (membership_id, role_id, is_active)
+    SELECT v_m_view,    id, TRUE FROM ref_org_business_role WHERE code = 'viewer';
+  INSERT INTO user_org_business_role (membership_id, role_id, is_active)
+    SELECT v_m_contrib, id, TRUE FROM ref_org_business_role WHERE code = 'contributor';
+  INSERT INTO user_org_business_role (membership_id, role_id, is_active)
+    SELECT v_m_editor,  id, TRUE FROM ref_org_business_role WHERE code = 'editor';
+
+  -- editor also holds an org_admin admin role (to edit/archive ANY team note)
+  INSERT INTO user_org_admin_role (membership_id, role_id, is_active)
+    SELECT v_m_editor, id, TRUE FROM ref_org_admin_role WHERE code = 'org_admin';
+
+  -- per-convention user_permission grants (direct insert; bypasses the anti-self RPC checks)
+  INSERT INTO user_permission (user_id, permission_id, is_active, granted_by, granted_at, created_at, updated_at)
+    SELECT v_contrib_uid, id, TRUE, v_editor_uid, NOW(), NOW(), NOW()
+    FROM ref_permission WHERE code IN
+      ('create_object','edit_canonical_when_publisher','edit_org_enrichment','edit_hours','edit_pricing','edit_gallery','attach_documents');
+  INSERT INTO user_permission (user_id, permission_id, is_active, granted_by, granted_at, created_at, updated_at)
+    SELECT v_editor_uid, id, TRUE, v_editor_uid, NOW(), NOW(), NOW()
+    FROM ref_permission WHERE code IN
+      ('create_object','edit_canonical_when_publisher','edit_org_enrichment','edit_hours','edit_pricing','edit_gallery','attach_documents','publish_object','validate_changes','manage_team_messages');
+
+  -- a note authored by the viewer (set up as postgres so we can test edit-by-others)
+  INSERT INTO object_private_description (object_id, org_object_id, created_by_user_id, audience, body)
+    VALUES (v_obj, v_org, v_view_uid, 'private', 'viewer note') RETURNING id INTO v_note_view;
+
+  -- ---------- Assertions: authorization helpers (SECURITY DEFINER read auth.uid() from the GUC) ----------
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_view_uid,    'role','authenticated')::text, true);
+  ASSERT api.user_can_write_object_canonical(v_obj) = FALSE, 'viewer must NOT write canonical';
+
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_contrib_uid, 'role','authenticated')::text, true);
+  ASSERT api.user_can_write_object_canonical(v_obj) = TRUE,  'contributor MUST write canonical';
+  ASSERT api.user_can_publish_object(v_obj)        = FALSE,  'contributor must NOT publish';
+
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_editor_uid,  'role','authenticated')::text, true);
+  ASSERT api.user_can_write_object_canonical(v_obj) = TRUE,  'editor MUST write canonical';
+  ASSERT api.user_can_publish_object(v_obj)        = TRUE,   'editor MUST publish';
+
+  -- ---------- Status guard: contributor (canonical, no publish) cannot change status ----------
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_contrib_uid, 'role','authenticated')::text, true);
+  BEGIN
+    SET LOCAL ROLE authenticated;
+    UPDATE object SET status = 'published' WHERE id = v_obj;
+    RAISE EXCEPTION 'STATUS GUARD FAILED: contributor changed status without publish_object';
+  EXCEPTION
+    WHEN insufficient_privilege THEN NULL;  -- expected: SQLSTATE 42501 from trg_guard_object_status_change
+  END;
+  RESET ROLE;
+
+  -- editor CAN publish (has publish_object): RLS allows + guard passes
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_editor_uid, 'role','authenticated')::text, true);
+  SET LOCAL ROLE authenticated;
+  UPDATE object SET status = 'published' WHERE id = v_obj;
+  GET DIAGNOSTICS v_rc = ROW_COUNT;
+  RESET ROLE;
+  ASSERT v_rc = 1, 'editor MUST be able to publish (1 row)';
+
+  -- ---------- Team notes: membership create, edit-own, admin-edit-any ----------
+  -- viewer creates a note (membership) and edits OWN
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_view_uid, 'role','authenticated')::text, true);
+  SET LOCAL ROLE authenticated;
+  INSERT INTO object_private_description (object_id, org_object_id, created_by_user_id, audience, body)
+    VALUES (v_obj, v_org, v_view_uid, 'private', 'viewer second note');
+  UPDATE object_private_description SET body = 'viewer edited own' WHERE id = v_note_view;
+  GET DIAGNOSTICS v_rc = ROW_COUNT;
+  RESET ROLE;
+  ASSERT v_rc = 1, 'viewer MUST edit own note';
+
+  -- contributor cannot edit the viewer's note (not author, not admin) -> RLS denies (0 rows)
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_contrib_uid, 'role','authenticated')::text, true);
+  SET LOCAL ROLE authenticated;
+  UPDATE object_private_description SET body = 'contrib tries' WHERE id = v_note_view;
+  GET DIAGNOSTICS v_rc = ROW_COUNT;
+  RESET ROLE;
+  ASSERT v_rc = 0, 'contributor must NOT edit another members note';
+
+  -- editor (org_admin) edits ANY note
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_editor_uid, 'role','authenticated')::text, true);
+  SET LOCAL ROLE authenticated;
+  UPDATE object_private_description SET body = 'admin edited' WHERE id = v_note_view;
+  GET DIAGNOSTICS v_rc = ROW_COUNT;
+  RESET ROLE;
+  ASSERT v_rc = 1, 'org_admin editor MUST edit any note';
+
+  RAISE NOTICE 'SP-2 behavioral assertions passed.';
+END$$;
+
+ROLLBACK;

--- a/README.md
+++ b/README.md
@@ -14,11 +14,28 @@ Bertel/
 │   ├── *.json                     # Collections Postman
 │   └── README.md                  # Guide documentation
 ├── Base de donnée DLL et API/     # Schéma de base de données unifié
-│   ├── schema_unified.sql         # Schéma complet avec système unifié
-│   ├── api_views_functions.sql    # Vues et fonctions API (RPC)
-│   ├── seeds_data.sql             # Données de test
-│   ├── rls_policies.sql           # Politiques de sécurité
-│   ├── ui_whitelabel_branding.sql # Branding UI et paramètres white-label
+│   ├── [Fresh install core]
+│   │   ├── schema_unified.sql
+│   │   ├── migration_sustainability_v5.sql
+│   │   ├── migration_room_type_ref.sql
+│   │   ├── migration_tag_link_position.sql
+│   │   ├── api_views_functions.sql
+│   │   ├── rls_policies.sql
+│   │   ├── object_workspace_safe_write_rpcs.sql
+│   │   ├── object_workspace_gap_rpcs.sql
+│   │   ├── ui_whitelabel_branding.sql
+│   │   ├── media_bucket.sql
+│   │   └── seeds_data.sql
+│   ├── [Post-seed / post-import fixups]
+│   │   ├── migration_legal_siret_canonical.sql
+│   │   └── migration_object_location_address1_dedupe.sql
+│   ├── [Maintenance and benchmarks]
+│   │   ├── maintenance.sql
+│   │   └── test_performance.sql
+│   ├── [Upgrade-only patch]
+│   │   └── branding_admin_profile_role_patch.sql
+│   ├── [Local / pilot-only inserts]
+│   │   └── lot1_pilot_inserts.sql
 │   ├── README.md                  # Documentation technique complète
 │   └── erd_diagram.md             # Diagramme ER en Mermaid
 ├── bertel-tourism-ui/             # Application Next.js (front-end)
@@ -88,22 +105,44 @@ psql -d votre_database -c "CREATE EXTENSION IF NOT EXISTS \"postgis\";"
 psql -d votre_database -c "CREATE EXTENSION IF NOT EXISTS \"unaccent\" WITH SCHEMA extensions;"
 psql -d votre_database -c "CREATE EXTENSION IF NOT EXISTS \"pg_trgm\";"
 psql -d votre_database -c "CREATE EXTENSION IF NOT EXISTS btree_gist;"
+psql -d votre_database -c "CREATE EXTENSION IF NOT EXISTS pgcrypto;"
 # Optionnel: psql -d votre_database -c "CREATE EXTENSION IF NOT EXISTS pg_cron;"
 
-# 1. Exécuter le schéma principal
+# 1. Schéma principal
 psql -d votre_database -f "Base de donnée DLL et API/schema_unified.sql"
 
-# 2. Exécuter les vues et fonctions API
+# 2. Migrations DDL — AVANT api/seeds (ajoutent des colonnes/tables requises)
+psql -d votre_database -f "Base de donnée DLL et API/migration_sustainability_v5.sql"
+psql -d votre_database -f "Base de donnée DLL et API/migration_room_type_ref.sql"
+psql -d votre_database -f "Base de donnée DLL et API/migration_tag_link_position.sql"
+
+# 3. Vues et fonctions API
 psql -d votre_database -f "Base de donnée DLL et API/api_views_functions.sql"
 
-# 3. Exécuter les politiques RLS
+# 4. Politiques RLS (définit api.is_object_owner)
 psql -d votre_database -f "Base de donnée DLL et API/rls_policies.sql"
 
-# 4. Installer le branding UI et les paramètres white-label
+# 5. RPC d'écriture éditeur (schéma internal + garde d'écriture, puis sections restantes)
+psql -d votre_database -f "Base de donnée DLL et API/object_workspace_safe_write_rpcs.sql"
+psql -d votre_database -f "Base de donnée DLL et API/object_workspace_gap_rpcs.sql"
+
+# 5b. SP-1 autorisation d'écriture canonique (après les RPC workspace, avant le branding)
+psql -d votre_database -f "Base de donnée DLL et API/migration_permission_write_paths.sql"
+
+# 6. Branding UI white-label (fichier complet pour une installation neuve)
 psql -d votre_database -f "Base de donnée DLL et API/ui_whitelabel_branding.sql"
 
-# 5. Peupler avec les données de test
+# 7. Bucket de stockage media (+ RLS d'écriture restrictive)
+psql -d votre_database -f "Base de donnée DLL et API/media_bucket.sql"
+
+# 8. Peupler avec les données de seed (nécessite migration_sustainability_v5 ci-dessus)
 psql -d votre_database -f "Base de donnée DLL et API/seeds_data.sql"
+
+# 9. Correctifs de données APRÈS seeds (no-op sur une base neuve sans données importées)
+psql -d votre_database -f "Base de donnée DLL et API/migration_legal_siret_canonical.sql"
+psql -d votre_database -f "Base de donnée DLL et API/migration_object_location_address1_dedupe.sql"
+
+# Ordre complet, refresh des vues matérialisées et rollback : voir docs/SQL_ROLLOUT_RUNBOOK.md
 ```
 
 ### Test de l'API

--- a/bertel-tourism-ui/Dockerfile
+++ b/bertel-tourism-ui/Dockerfile
@@ -53,5 +53,8 @@ WORKDIR /app
 
 EXPOSE 3000
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD wget -qO- "http://127.0.0.1:${PORT:-3000}/api/health" >/dev/null || exit 1
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/bertel-tourism-ui/src/app/api/health/route.test.ts
+++ b/bertel-tourism-ui/src/app/api/health/route.test.ts
@@ -1,0 +1,15 @@
+/** @jest-environment node */
+import { GET } from './route';
+
+describe('GET /api/health', () => {
+  it('returns a healthy JSON response', async () => {
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      service: 'bertel-tourism-ui',
+    });
+  });
+});

--- a/bertel-tourism-ui/src/app/api/health/route.ts
+++ b/bertel-tourism-ui/src/app/api/health/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<NextResponse> {
+  return NextResponse.json({
+    ok: true,
+    service: 'bertel-tourism-ui',
+  });
+}

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -2,6 +2,8 @@ FROM nginx:alpine
 
 # Copier la documentation
 COPY index.html /usr/share/nginx/html/
+COPY *.md /usr/share/nginx/html/
+COPY *.json /usr/share/nginx/html/
 
 # Configuration Nginx pour SPA
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@ docker run -p 8080:80 bertel-api-docs
 ## 📁 Structure
 
 - `index.html` - Documentation principale
+- `SQL_ROLLOUT_RUNBOOK.md` - Runbook équipe pour installation, mise à jour SQL, refresh MV et rollback
+- `SUPABASE_SETUP.md` - Configuration Supabase/PostgREST du schéma `api`
 - `Bertel_API_v3.postman_collection.json` - Collection Postman
 - `Bertel_API_v3.postman_environment.json` - Environnement Postman
 - `README_Postman.md` - Guide d'utilisation Postman
@@ -44,6 +46,7 @@ docker run -p 8080:80 bertel-api-docs
 - **Mode sombre/clair** avec persistance
 - **Recherche globale** dans la documentation
 - **Collection Postman** intégrée
+- **Espace équipe** en haut de `index.html` pour accéder aux runbooks SQL/Supabase et aux artefacts Postman
 - **Bouton flottant** pour toggle des sections
 - **Responsive design** pour tous les écrans
 

--- a/docs/SQL_ROLLOUT_RUNBOOK.md
+++ b/docs/SQL_ROLLOUT_RUNBOOK.md
@@ -2,30 +2,65 @@
 
 ## Scope
 
-This runbook covers phased rollout and verification for SQL updates in:
-- `Base de donnée DLL et API/schema_unified.sql`
-- `Base de donnée DLL et API/api_views_functions.sql`
-- `Base de donnée DLL et API/rls_policies.sql`
-- `Base de donnée DLL et API/ui_whitelabel_branding.sql`
-- `Base de donnée DLL et API/test_performance.sql`
+This runbook covers two paths:
+- **Fresh install** — build a new database from scratch. Follow the *complete ordered manifest* below; it is the authoritative apply order.
+- **Incremental update** — push SQL changes to an already-deployed database (perf/policy/function refresh). Follow *Incremental Update Order* further down.
+
+Top-level SQL file inventory (in `Base de donnée DLL et API/`):
+- **Fresh-install core:** `schema_unified.sql`; `migration_sustainability_v5.sql`, `migration_room_type_ref.sql`, `migration_tag_link_position.sql`; `api_views_functions.sql`; `rls_policies.sql`; `object_workspace_safe_write_rpcs.sql`; `object_workspace_gap_rpcs.sql`; `ui_whitelabel_branding.sql`; `media_bucket.sql`; `seeds_data.sql`.
+- **Post-seed / post-import fixups:** `migration_legal_siret_canonical.sql`, `migration_object_location_address1_dedupe.sql`.
+- **Maintenance and benchmarks:** `maintenance.sql`, `test_performance.sql`.
+- **Upgrade-only patch:** `branding_admin_profile_role_patch.sql` for databases that ran an older branding migration; not part of a fresh install.
+- **Local / pilot-only inserts:** `lot1_pilot_inserts.sql` is marked `LOCAL ONLY`; use only for the Lot 1 pilot data path after prerequisites are applied.
 
 ## Pre-Deployment Checklist
 
 1. Confirm backup/restore path is valid for the target Supabase project.
 2. Confirm migration window and rollback owner.
 3. Confirm expected API compatibility (no signature or JSON shape breaks).
-4. Confirm required extensions are enabled (`postgis`, `pgcrypto`, `uuid-ossp`, `pg_cron` if used).
+4. Confirm required extensions are enabled (`postgis`, `pgcrypto`, `uuid-ossp`, `pg_trgm`, `btree_gist`, `unaccent`, `pg_cron` if used).
 
-## Deployment Order
+## Fresh Database — Complete Ordered Manifest (authoritative)
 
-1. `schema_unified.sql` (indexes and schema-level changes)
-2. `api_views_functions.sql` (function updates)
-3. `rls_policies.sql` (policy refresh/hardening)
-4. `ui_whitelabel_branding.sql` (UI branding/settings table and RPCs)
-5. Refresh materialized views introduced by this rollout:
-   - `REFRESH MATERIALIZED VIEW CONCURRENTLY mv_ref_data_json;`
-   - `REFRESH MATERIALIZED VIEW CONCURRENTLY mv_filtered_objects;`
-6. Smoke tests on key endpoints
+A fresh database MUST be built in this exact order; each step depends on the previous. Verified 2026-06-02 against live PROD (every object below exists there) — see `bertel-tourism-ui/claude_brief/lot1_mapping_decisions.md` §24 (P0.1). Skipping the migrations/RPCs/bucket (as the old order did) leaves a fresh DB that **cannot save tags or room-types and errors on the V5 sustainability seeds**.
+
+0. **Extensions:** `uuid-ossp`, `postgis`, `unaccent` (schema `extensions`), `pg_trgm`, `btree_gist`, `pgcrypto`; `pg_cron` optional.
+1. `schema_unified.sql`
+2. `migration_sustainability_v5.sql` — DDL; **prerequisite for the V5 sections of `seeds_data.sql`** (creates `ref_sustainability_action_group` + equivalence tables/views).
+3. `migration_room_type_ref.sql` — DDL; adds `object_room_type.room_type_id`.
+4. `migration_tag_link_position.sql` — DDL; adds `tag_link.position` (required at runtime by `api.save_object_workspace_tags`).
+5. `api_views_functions.sql`
+6. `rls_policies.sql` — defines `api.is_object_owner` (needed by step 7).
+7. `object_workspace_safe_write_rpcs.sql` — creates schema `internal` + the write gate `internal.workspace_assert_can_write_object`.
+8. `object_workspace_gap_rpcs.sql` — depends on step 7 and on the columns from steps 2 & 4.
+8b. `migration_permission_write_paths.sql` — **SP-1 canonical-write authorization**: additive `api.user_can_write_object_canonical` substituted into the workspace gate + 23 write policies, plus the `object.status` guard trigger. After the workspace RPCs (depends on `rls_policies.sql` helpers + the gate); before branding.
+9. `ui_whitelabel_branding.sql` — defines `api.is_platform_admin` (a fresh install uses this full file, not the patch).
+10. `media_bucket.sql` — `media` storage bucket + RESTRICTIVE anon/authenticated write-deny.
+11. `seeds_data.sql` — depends on `ref_sustainability_action_group` from step 2.
+12. `migration_legal_siret_canonical.sql` — **data fixup; run AFTER seeds** (updates seeded `ref_legal_type` rows; safe no-op on `object_legal` when empty).
+13. `migration_object_location_address1_dedupe.sql` — post-import data hygiene (no-op on a fresh DB; re-run after each bulk import).
+14. `REFRESH MATERIALIZED VIEW CONCURRENTLY internal.mv_ref_data_json;` then `REFRESH MATERIALIZED VIEW CONCURRENTLY internal.mv_filtered_objects;`
+15. Smoke tests (see Verification below).
+
+**Upgrade-only — NOT part of a fresh install:** `branding_admin_profile_role_patch.sql` (only for databases that ran an older `ui_whitelabel_branding.sql` before its admin guard checked `app_user_profile.role`).
+
+Fresh-install migrations and post-seed fixups use idempotent DDL/data patterns and are transaction-wrapped where the files contain `BEGIN`/`COMMIT`. RPC scripts are idempotent through `CREATE OR REPLACE` plus grants/revokes; review local/pilot-only scripts before reapplying.
+
+### CI enforcement (deploy integrity)
+A GitHub Actions gate, `.github/workflows/sql-fresh-apply.yml`, executes this manifest against a fresh Supabase local database on every change to `Base de donnée DLL et API/*.sql`, via the executable driver `Base de donnée DLL et API/ci_fresh_apply.sql` (which mirrors the manifest exactly, with `ON_ERROR_STOP`). If a migration is ever applied only to live PROD and never folded into the manifest/files, a fresh apply diverges and the gate goes red. Run it on demand from the Actions tab (**Run workflow** / `workflow_dispatch`). The driver is also the recommended way to bootstrap a local dev DB: `psql "$LOCAL_DB_URL" -v ON_ERROR_STOP=1 -f "Base de donnée DLL et API/ci_fresh_apply.sql"`.
+
+## Incremental Update Order
+
+> For routine SQL **updates** to an already-deployed database. A **fresh** install must follow the complete manifest above. For incremental updates, apply every changed DDL/RPC/storage file in the same dependency order as the fresh manifest before verification.
+
+1. Apply changed schema/DDL/storage files in manifest order: `schema_unified.sql`, changed `migration_*.sql`, and `media_bucket.sql` if bucket or storage RLS changed.
+2. Apply changed API, RLS, and RPC files in dependency order: `api_views_functions.sql`, `rls_policies.sql`, `object_workspace_safe_write_rpcs.sql`, `object_workspace_gap_rpcs.sql`, `ui_whitelabel_branding.sql`.
+3. Apply changed post-seed/post-import fixups only when their preconditions match the target database.
+4. Reload the PostgREST schema cache after function, grant, or exposed-schema changes: `NOTIFY pgrst, 'reload schema';`
+5. Refresh materialized views introduced or affected by the update:
+   - `REFRESH MATERIALIZED VIEW CONCURRENTLY internal.mv_ref_data_json;`
+   - `REFRESH MATERIALIZED VIEW CONCURRENTLY internal.mv_filtered_objects;`
+6. Smoke tests on key endpoints.
 
 ## Verification (Before/After)
 
@@ -111,14 +146,14 @@ Use a cadence aligned with your accepted staleness budget:
 SELECT cron.schedule(
   'refresh-mv-filtered-objects',
   '*/10 * * * *',
-  $$REFRESH MATERIALIZED VIEW CONCURRENTLY mv_filtered_objects;$$
+  $$REFRESH MATERIALIZED VIEW CONCURRENTLY internal.mv_filtered_objects;$$
 );
 ```
 
 Health checks:
 
 ```sql
-SELECT COUNT(*) AS mv_rows FROM mv_filtered_objects;
+SELECT COUNT(*) AS mv_rows FROM internal.mv_filtered_objects;
 SELECT COUNT(*) AS baseline_rows
 FROM object o
 JOIN object_location ol ON ol.object_id = o.id AND ol.is_main_location IS TRUE

--- a/docs/SUPABASE_SETUP.md
+++ b/docs/SUPABASE_SETUP.md
@@ -4,7 +4,7 @@ This project exposes read models and RPCs from the `api` schema through PostgRES
 
 ### 1) Required database extensions
 
-Run once on your database (already included in `schema_unified.sql`, but safe to re-run):
+Run once on your database (already included in `schema_unified.sql` and `migration_sustainability_v5.sql` where applicable, but safe to re-run):
 
 ```sql
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
@@ -12,7 +12,10 @@ CREATE EXTENSION IF NOT EXISTS "postgis";
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pg_trgm";
 CREATE EXTENSION IF NOT EXISTS btree_gist;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 ```
+
+Enable `pg_cron` only if you schedule SQL maintenance jobs from the database.
 
 If your platform installs extensions into the `extensions` schema (Supabase default), make sure the REST service search_path includes it (see step 2b).
 
@@ -67,11 +70,15 @@ If you use Supabase Cloud (hosted by Supabase), configure the REST API from Stud
 NOTIFY pgrst, 'reload schema';
 ```
 
-3) Ensure extensions exist (run once in SQL editor):
+3) Ensure extensions exist (run once in SQL editor, aligned with the SQL rollout runbook):
 
 ```sql
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "postgis";
 CREATE EXTENSION IF NOT EXISTS "unaccent";
 CREATE EXTENSION IF NOT EXISTS "pg_trgm";
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 ```
 
 4) Grant permissions (run once in SQL editor, least privilege):
@@ -127,17 +134,17 @@ Notes:
 SELECT cron.schedule(
   'refresh-mv-filtered-objects',
   '*/10 * * * *',
-  $$REFRESH MATERIALIZED VIEW CONCURRENTLY mv_filtered_objects;$$
+  $$REFRESH MATERIALIZED VIEW CONCURRENTLY internal.mv_filtered_objects;$$
 );
 
 -- Run immediately after deploying schema/function changes
-REFRESH MATERIALIZED VIEW CONCURRENTLY mv_filtered_objects;
+REFRESH MATERIALIZED VIEW CONCURRENTLY internal.mv_filtered_objects;
 ```
 
 Recommended monitor checks:
 
 ```sql
-SELECT COUNT(*) AS mv_rows FROM mv_filtered_objects;
+SELECT COUNT(*) AS mv_rows FROM internal.mv_filtered_objects;
 SELECT COUNT(*) AS published_main_location_rows
 FROM object o
 JOIN object_location ol ON ol.object_id = o.id AND ol.is_main_location IS TRUE

--- a/docs/index.html
+++ b/docs/index.html
@@ -777,12 +777,12 @@
       <img class="logo" alt="OTI du Sud" src="https://supabertel.otisud.re/storage/v1/object/public/logo//logo200X200.png">
       <div class="title">
         <strong>OTI du SUD · API</strong>
-        <small>Documentation complète & bonnes pratiques</small>
+        <small>API, runbooks équipe & bonnes pratiques</small>
       </div>
       </div>
       <div class="header-right">
         <div class="searchbar">
-          <input id="globalSearch" type="search" placeholder="Rechercher dans la doc (endpoints, paramètres, champs…)">
+          <input id="globalSearch" type="search" placeholder="Rechercher dans la doc (endpoints, runbooks, paramètres…)">
         </div>
       <div class="actions">
         <span class="chip" title="Version de la page">v1</span>
@@ -805,6 +805,59 @@
       <section class="card" id="intro">
         <h1>Documentation de l’API</h1>
         <p class="lead">Une API structurée autour d'appels <code>/rpc/&lt;nom_fonction&gt;</code> via <b>POST</b>, avec pagination, filtres riches et extraction des tracés KML/GPX pour les itinéraires.</p>
+      </section>
+
+      <section class="card" id="team-ops">
+        <h2>0) Espace équipe & exploitation SQL</h2>
+        <p class="lead">Points d'entrée pour l'équipe projet avant une installation, une mise à jour SQL ou une session de test API.</p>
+
+        <table>
+          <thead>
+            <tr><th>Besoin</th><th>Document</th><th>Quand l'utiliser</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><span class="badge">Déploiement SQL</span></td>
+              <td><a href="SQL_ROLLOUT_RUNBOOK.md">SQL_ROLLOUT_RUNBOOK.md</a></td>
+              <td>Ordre d'installation fraîche, mises à jour incrémentales, refresh des vues matérialisées et rollback.</td>
+            </tr>
+            <tr>
+              <td><span class="badge">Supabase</span></td>
+              <td><a href="SUPABASE_SETUP.md">SUPABASE_SETUP.md</a></td>
+              <td>Configuration PostgREST du schéma <code>api</code>, extensions PostgreSQL, permissions et cache schema.</td>
+            </tr>
+            <tr>
+              <td><span class="badge">Tests API</span></td>
+              <td><a href="README_Postman.md">README_Postman.md</a></td>
+              <td>Préparer l'environnement Postman et lancer les collections de validation.</td>
+            </tr>
+            <tr>
+              <td><span class="badge">Collection</span></td>
+              <td><a href="Bertel_API_v3.postman_collection.json">Collection</a> · <a href="Bertel_API_v3.postman_environment.json">Environnement</a></td>
+              <td>Importer ou mettre à jour les appels API partagés par l'équipe.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <details id="team-sql-order">
+          <summary>0.1 Résumé SQL opérationnel</summary>
+          <div class="content">
+            <ul>
+              <li>Pour une base neuve, suivre le manifeste complet du runbook SQL dans l'ordre exact.</li>
+              <li>Extensions attendues : <code>uuid-ossp</code>, <code>postgis</code>, <code>unaccent</code>, <code>pg_trgm</code>, <code>btree_gist</code>, <code>pgcrypto</code>; <code>pg_cron</code> uniquement si les tâches SQL planifiées sont activées.</li>
+              <li>Les refreshs doivent cibler <code>internal.mv_ref_data_json</code> et <code>internal.mv_filtered_objects</code>.</li>
+              <li><code>lot1_pilot_inserts.sql</code> reste local/pilote : ne pas l'appliquer dans une installation standard sans décision explicite.</li>
+            </ul>
+          </div>
+        </details>
+
+        <details id="team-source-truth">
+          <summary>0.2 Sources de vérité</summary>
+          <div class="content">
+            <p>La documentation API ci-dessous décrit les contrats consommateur. Pour l'ordre SQL, les prérequis Supabase et les scripts opérationnels, le runbook SQL et le guide Supabase restent les documents de référence.</p>
+            <p class="inline-help">Dans le dépôt, la documentation technique détaillée du schéma reste dans <code>Base de donnée DLL et API/README.md</code>.</p>
+          </div>
+        </details>
       </section>
 
       <!-- 1) Auth & conventions -->

--- a/docs/superpowers/plans/2026-06-02-sp1-canonical-write-auth.md
+++ b/docs/superpowers/plans/2026-06-02-sp1-canonical-write-auth.md
@@ -1,0 +1,489 @@
+# SP‑1 Canonical-write Authorization — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Level‑2 canonical-write permission a valid path to write an object's canonical data — additively alongside the legacy owner path — across the editor's RLS write surface and the workspace gate, without regressing the existing superuser and without letting canonical-editors change publication status.
+
+**Architecture:** One new helper `api.user_can_write_object_canonical(obj) = is_object_owner(obj) OR user_can_write_canonical(obj)` becomes the single predicate substituted into 23 write policies + the workspace gate. A `BEFORE UPDATE OF status` trigger keeps publish (`publish_object`) distinct from canonical edit. All shipped as one idempotent, reversible migration slotted into the deploy manifest after the workspace RPCs. SP‑1 is **inert on live today** (0 permission grants, 1 superuser) — it only opens the path; SP‑2 grants permissions and adds the behavioral tests.
+
+**Tech Stack:** PostgreSQL/Supabase RLS, `psql`, Supabase CLI local DB (`supabase start`). Spec: `docs/superpowers/specs/2026-06-02-sp1-canonical-write-auth-design.md`.
+
+**Execution prerequisite:** a running Supabase local DB with the full base manifest applied (`supabase start`, then `ci_fresh_apply.sql`). Requires Docker. The CI gate (`.github/workflows/sql-fresh-apply.yml`) provides the same environment. Local DB URL: `postgresql://postgres:postgres@127.0.0.1:54322/postgres`.
+
+---
+
+## File structure
+
+- **Create** `Base de donnée DLL et API/migration_permission_write_paths.sql` — all SP‑1 DDL (helper, gate, 23 policy substitutions, status trigger). One cohesive, idempotent, transaction-wrapped migration.
+- **Create** `Base de donnée DLL et API/tests/test_sp1_canonical_write_auth.sql` — deterministic catalog assertions (helper/trigger exist; gate + all targeted policies reference the new helper). No user fixture (behavioral tests are SP‑2).
+- **Modify** `Base de donnée DLL et API/ci_fresh_apply.sql` — apply the migration after `object_workspace_gap_rpcs.sql`.
+- **Modify** `.github/workflows/sql-fresh-apply.yml` — run the catalog test after the manifest applies.
+- **Modify** `docs/SQL_ROLLOUT_RUNBOOK.md`, `README.md`, `Base de donnée DLL et API/README.md` — add the migration to the ordered manifest (new step after `object_workspace_gap_rpcs.sql`).
+- **Modify** `CLAUDE.md` — the "Write-path authorization (target — P0.2)" invariant becomes established (additively) by SP‑1.
+- **Modify** `bertel-tourism-ui/claude_brief/lot1_mapping_decisions.md` §24 — mark SP‑1 done; note behavioral verification deferred to SP‑2.
+
+---
+
+## Task 1: Failing structural test
+
+**Files:**
+- Create: `Base de donnée DLL et API/tests/test_sp1_canonical_write_auth.sql`
+
+- [ ] **Step 1: Write the test (deterministic catalog assertions)**
+
+```sql
+-- test_sp1_canonical_write_auth.sql
+-- SP-1 structural assertions. Run AFTER the base manifest + migration_permission_write_paths.sql.
+-- Deterministic (catalog-only): asserts the helper + status trigger exist, the workspace gate
+-- is wired to the helper, and every targeted write policy now references the helper.
+-- Behavioral (granted-contributor can write / cannot publish) tests are SP-2.
+\set ON_ERROR_STOP on
+DO $$
+DECLARE
+  v_missing text[] := ARRAY[]::text[];
+  v_legacy  text[];
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+                 WHERE n.nspname='api' AND p.proname='user_can_write_object_canonical') THEN
+    v_missing := v_missing || 'api.user_can_write_object_canonical';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger
+                 WHERE tgname='trg_guard_object_status_change' AND NOT tgisinternal) THEN
+    v_missing := v_missing || 'trg_guard_object_status_change';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+                 WHERE n.nspname='internal' AND p.proname='workspace_assert_can_write_object'
+                   AND pg_get_functiondef(p.oid) LIKE '%user_can_write_object_canonical%') THEN
+    v_missing := v_missing || 'workspace gate not wired to helper';
+  END IF;
+
+  IF array_length(v_missing, 1) > 0 THEN
+    RAISE EXCEPTION 'SP-1 objects missing: %', array_to_string(v_missing, ', ');
+  END IF;
+
+  -- Every targeted write policy must reference the helper in its USING (qual).
+  -- object_description is intentionally excluded (carve-out keeps is_object_owner OR
+  -- (user_can_write_canonical AND org_object_id IS NULL)).
+  SELECT array_agg(policyname) INTO v_legacy
+  FROM pg_policies
+  WHERE schemaname='public'
+    AND policyname IN (
+      'owner_write_location','owner_write_place','owner_write_contact','owner_write_media',
+      'owner_write_legal','owner_write_discount','owner_write_group_policy',
+      'owner_price_write','owner_price_period_write','owner_menu_write','owner_menu_item_write',
+      'owner_menu_item_dietary_write','owner_menu_item_allergen_write','owner_menu_item_cuisine_write',
+      'owner_menu_item_media_write','owner_meeting_room_write','owner_meeting_room_equipment_write',
+      'owner_pet_policy_write','owner_fma_occurrence_write','owner_iti_stage_media_write',
+      'owner_object_membership_write','owner_update_object','owner_delete_object'
+    )
+    AND COALESCE(qual,'') NOT LIKE '%user_can_write_object_canonical%';
+  IF v_legacy IS NOT NULL THEN
+    RAISE EXCEPTION 'Policies still on legacy predicate (not wired to helper): %', array_to_string(v_legacy, ', ');
+  END IF;
+
+  -- object_description carve-out: must reference BOTH the canonical helper and the overlay guard.
+  IF NOT EXISTS (SELECT 1 FROM pg_policies
+                 WHERE schemaname='public' AND policyname='owner_write_description'
+                   AND qual LIKE '%user_can_write_canonical%' AND qual LIKE '%org_object_id%') THEN
+    RAISE EXCEPTION 'owner_write_description carve-out (canonical + org_object_id IS NULL) not in place';
+  END IF;
+
+  RAISE NOTICE 'SP-1 structural assertions passed.';
+END$$;
+```
+
+- [ ] **Step 2: Run the test against the current DB (pre-migration) and confirm it FAILS**
+
+Run (against a DB with the base manifest applied but NOT the SP‑1 migration):
+```bash
+psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -v ON_ERROR_STOP=1 \
+  -f "Base de donnée DLL et API/tests/test_sp1_canonical_write_auth.sql"
+```
+Expected: **FAIL** — `ERROR: SP-1 objects missing: api.user_can_write_object_canonical, trg_guard_object_status_change, workspace gate not wired to helper` (the helper/trigger don't exist yet). This proves the test is meaningful.
+
+- [ ] **Step 3: Commit the test**
+
+```bash
+git add "Base de donnée DLL et API/tests/test_sp1_canonical_write_auth.sql"
+git commit -m "test(sql): SP-1 structural assertions for canonical-write authorization"
+```
+
+---
+
+## Task 2: Write the migration
+
+**Files:**
+- Create: `Base de donnée DLL et API/migration_permission_write_paths.sql`
+
+- [ ] **Step 1: Create the migration file with this exact content**
+
+```sql
+-- migration_permission_write_paths.sql
+-- SP-1 of P0.2 — canonical-write authorization wired into the editor write paths.
+-- Substitutes the legacy `api.is_object_owner(...)` predicate with the ADDITIVE
+-- `api.user_can_write_object_canonical(...)` (= is_object_owner OR user_can_write_canonical)
+-- across the workspace gate + the 23 object/child-table write policies, and adds a
+-- status-change guard so edit_canonical_when_publisher != publish_object.
+--
+-- PREREQUISITES: schema_unified.sql, rls_policies.sql (defines is_object_owner,
+--   user_can_write_canonical, user_can_publish_object, is_platform_superuser),
+--   object_workspace_safe_write_rpcs.sql (the gate). APPLY AFTER object_workspace_gap_rpcs.sql.
+-- IDEMPOTENT: CREATE OR REPLACE + DROP POLICY/TRIGGER IF EXISTS. TRANSACTION-WRAPPED.
+-- REVERSIBLE: see docs/superpowers/specs/2026-06-02-sp1-canonical-write-auth-design.md §7.
+-- INERT until SP-2 grants permissions (0 grants on live today); additive => no regression.
+
+BEGIN;
+
+-- 1) Single source of truth for canonical-write authorization (additive OR).
+CREATE OR REPLACE FUNCTION api.user_can_write_object_canonical(p_object_id text)
+RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, api, auth
+AS $fn$
+  SELECT api.is_object_owner(p_object_id)            -- legacy actor-owner + service_role/admin + platform superuser
+      OR api.user_can_write_canonical(p_object_id);  -- publisher ORG member holding edit_canonical_when_publisher
+$fn$;
+REVOKE EXECUTE ON FUNCTION api.user_can_write_object_canonical(text) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION api.user_can_write_object_canonical(text) TO authenticated, service_role;
+
+-- 2) Workspace gate (was: is_object_owner only).
+CREATE OR REPLACE FUNCTION internal.workspace_assert_can_write_object(p_object_id text)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, api, internal, auth
+AS $fn$
+BEGIN
+  IF p_object_id IS NULL OR btrim(p_object_id) = '' THEN
+    RAISE EXCEPTION 'object_id is required' USING ERRCODE = '22023';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.object WHERE id = p_object_id) THEN
+    RAISE EXCEPTION 'Unknown object_id: %', p_object_id USING ERRCODE = 'P0002';
+  END IF;
+  IF NOT api.user_can_write_object_canonical(p_object_id) THEN
+    RAISE EXCEPTION 'Current user cannot write object %', p_object_id USING ERRCODE = '42501';
+  END IF;
+END;
+$fn$;
+
+-- 3) object UPDATE / DELETE: created_by OR canonical writer.
+DROP POLICY IF EXISTS "owner_update_object" ON object;
+CREATE POLICY "owner_update_object" ON object
+  FOR UPDATE
+  USING      (auth.uid() = created_by OR api.user_can_write_object_canonical(id))
+  WITH CHECK (auth.uid() = created_by OR api.user_can_write_object_canonical(id));
+
+DROP POLICY IF EXISTS "owner_delete_object" ON object;
+CREATE POLICY "owner_delete_object" ON object
+  FOR DELETE
+  USING (auth.uid() = created_by OR api.user_can_write_object_canonical(id));
+
+-- 4) Simple child-table write policies (FOR ALL USING object_id).
+DROP POLICY IF EXISTS "owner_write_location" ON object_location;
+CREATE POLICY "owner_write_location" ON object_location
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_write_place" ON object_place;
+CREATE POLICY "owner_write_place" ON object_place
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_write_contact" ON contact_channel;
+CREATE POLICY "owner_write_contact" ON contact_channel
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_write_media" ON media;
+CREATE POLICY "owner_write_media" ON media
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_write_legal" ON object_legal;
+CREATE POLICY "owner_write_legal" ON object_legal
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_write_discount" ON object_discount;
+CREATE POLICY "owner_write_discount" ON object_discount
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_write_group_policy" ON object_group_policy;
+CREATE POLICY "owner_write_group_policy" ON object_group_policy
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_price_write" ON object_price;
+CREATE POLICY "owner_price_write" ON object_price
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_menu_write" ON object_menu;
+CREATE POLICY "owner_menu_write" ON object_menu
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_meeting_room_write" ON object_meeting_room;
+CREATE POLICY "owner_meeting_room_write" ON object_meeting_room
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_pet_policy_write" ON object_pet_policy;
+CREATE POLICY "owner_pet_policy_write" ON object_pet_policy
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+DROP POLICY IF EXISTS "owner_fma_occurrence_write" ON object_fma_occurrence;
+CREATE POLICY "owner_fma_occurrence_write" ON object_fma_occurrence
+  FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+-- 5) object_description carve-out: new canonical path is restricted to canonical rows
+--    (org_object_id IS NULL); per-org overlays stay the sole domain of rpc_write_org_description (§20).
+DROP POLICY IF EXISTS "owner_write_description" ON object_description;
+CREATE POLICY "owner_write_description" ON object_description
+  FOR ALL USING (
+    api.is_object_owner(object_id)
+    OR (api.user_can_write_canonical(object_id) AND org_object_id IS NULL)
+  );
+
+-- 6) Nested child policies (EXISTS via parent — substitute the inner is_object_owner).
+DROP POLICY IF EXISTS "owner_price_period_write" ON object_price_period;
+CREATE POLICY "owner_price_period_write" ON object_price_period
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_price op
+            WHERE op.id = object_price_period.price_id
+              AND api.user_can_write_object_canonical(op.object_id))
+  );
+
+DROP POLICY IF EXISTS "owner_menu_item_write" ON object_menu_item;
+CREATE POLICY "owner_menu_item_write" ON object_menu_item
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_menu om
+            WHERE om.id = object_menu_item.menu_id
+              AND api.user_can_write_object_canonical(om.object_id))
+  );
+
+DROP POLICY IF EXISTS "owner_menu_item_dietary_write" ON object_menu_item_dietary_tag;
+CREATE POLICY "owner_menu_item_dietary_write" ON object_menu_item_dietary_tag
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_menu_item omi
+            JOIN object_menu om ON om.id = omi.menu_id
+            WHERE omi.id = object_menu_item_dietary_tag.menu_item_id
+              AND api.user_can_write_object_canonical(om.object_id))
+  );
+
+DROP POLICY IF EXISTS "owner_menu_item_allergen_write" ON object_menu_item_allergen;
+CREATE POLICY "owner_menu_item_allergen_write" ON object_menu_item_allergen
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_menu_item omi
+            JOIN object_menu om ON om.id = omi.menu_id
+            WHERE omi.id = object_menu_item_allergen.menu_item_id
+              AND api.user_can_write_object_canonical(om.object_id))
+  );
+
+DROP POLICY IF EXISTS "owner_menu_item_cuisine_write" ON object_menu_item_cuisine_type;
+CREATE POLICY "owner_menu_item_cuisine_write" ON object_menu_item_cuisine_type
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_menu_item omi
+            JOIN object_menu om ON om.id = omi.menu_id
+            WHERE omi.id = object_menu_item_cuisine_type.menu_item_id
+              AND api.user_can_write_object_canonical(om.object_id))
+  );
+
+DROP POLICY IF EXISTS "owner_menu_item_media_write" ON object_menu_item_media;
+CREATE POLICY "owner_menu_item_media_write" ON object_menu_item_media
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_menu_item omi
+            JOIN object_menu om ON om.id = omi.menu_id
+            WHERE omi.id = object_menu_item_media.menu_item_id
+              AND api.user_can_write_object_canonical(om.object_id))
+  );
+
+DROP POLICY IF EXISTS "owner_meeting_room_equipment_write" ON meeting_room_equipment;
+CREATE POLICY "owner_meeting_room_equipment_write" ON meeting_room_equipment
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_meeting_room omr
+            WHERE omr.id = meeting_room_equipment.room_id
+              AND api.user_can_write_object_canonical(omr.object_id))
+  );
+
+DROP POLICY IF EXISTS "owner_iti_stage_media_write" ON object_iti_stage_media;
+CREATE POLICY "owner_iti_stage_media_write" ON object_iti_stage_media
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM object_iti_stage ois
+            WHERE ois.id = object_iti_stage_media.stage_id
+              AND api.user_can_write_object_canonical(ois.object_id))
+  );
+
+-- 7) object_membership (keeps the admin branch; COALESCE handles ORG-scoped memberships).
+DROP POLICY IF EXISTS "owner_object_membership_write" ON object_membership;
+CREATE POLICY "owner_object_membership_write" ON object_membership
+  FOR ALL USING (
+    auth.role() IN ('service_role','admin')
+    OR api.user_can_write_object_canonical(COALESCE(object_id, org_object_id))
+  );
+
+-- 8) Status guard: status changes require publish_object (rpc_publish_object), not edit_canonical.
+--    service_role/admin and platform superuser are exempt. rpc_publish_object verifies the
+--    caller's publish right before its UPDATE, so the trigger re-check passes for it
+--    (auth.uid() is preserved under SECURITY DEFINER). Fires only when `status` is in the SET list.
+CREATE OR REPLACE FUNCTION api.guard_object_status_change()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, api, auth
+AS $fn$
+BEGIN
+  IF NEW.status IS DISTINCT FROM OLD.status
+     AND auth.role() NOT IN ('service_role','admin')
+     AND NOT api.is_platform_superuser()
+     AND NOT api.user_can_publish_object(NEW.id)
+  THEN
+    RAISE EXCEPTION
+      'Object status changes require the publish_object permission (use api.rpc_publish_object); edit_canonical_when_publisher does not grant publishing'
+      USING ERRCODE = '42501';
+  END IF;
+  RETURN NEW;
+END;
+$fn$;
+REVOKE EXECUTE ON FUNCTION api.guard_object_status_change() FROM PUBLIC, anon;
+
+DROP TRIGGER IF EXISTS trg_guard_object_status_change ON object;
+CREATE TRIGGER trg_guard_object_status_change
+  BEFORE UPDATE OF status ON object
+  FOR EACH ROW EXECUTE FUNCTION api.guard_object_status_change();
+
+COMMIT;
+```
+
+- [ ] **Step 2: Eyeball-review the file** — confirm every `owner_*_write` / `owner_write_*` / `owner_update_object` / `owner_delete_object` / `owner_object_membership_write` policy is present (23 total) and that `object_description` uses the carve-out, not the blanket helper.
+
+---
+
+## Task 3: Apply the migration and make the test pass
+
+**Files:** (none changed; runs Task 1 + Task 2 artifacts)
+
+- [ ] **Step 1: Apply the migration**
+
+Run:
+```bash
+psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -v ON_ERROR_STOP=1 \
+  -f "Base de donnée DLL et API/migration_permission_write_paths.sql"
+```
+Expected: `COMMIT` with no error.
+
+- [ ] **Step 2: Run the structural test — expect PASS**
+
+Run:
+```bash
+psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -v ON_ERROR_STOP=1 \
+  -f "Base de donnée DLL et API/tests/test_sp1_canonical_write_auth.sql"
+```
+Expected: `NOTICE: SP-1 structural assertions passed.` and exit 0.
+
+- [ ] **Step 3: No-regression spot check (superuser/service path still writes)**
+
+Run:
+```bash
+psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -v ON_ERROR_STOP=1 -c \
+"SELECT api.user_can_write_object_canonical(id) AS ok, count(*) OVER () FROM object LIMIT 1;"
+```
+Expected: a row with `ok = t` (the `postgres`/service connection resolves `is_object_owner` true via `auth.role()`), confirming the legacy path is intact.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "Base de donnée DLL et API/migration_permission_write_paths.sql"
+git commit -m "feat(rls): SP-1 wire canonical-write permission into editor write paths (additive)"
+```
+
+---
+
+## Task 4: Wire the migration into the deploy manifest + CI
+
+**Files:**
+- Modify: `Base de donnée DLL et API/ci_fresh_apply.sql`
+- Modify: `.github/workflows/sql-fresh-apply.yml`
+- Modify: `docs/SQL_ROLLOUT_RUNBOOK.md`
+- Modify: `README.md`
+- Modify: `Base de donnée DLL et API/README.md`
+
+- [ ] **Step 1: Insert the migration into `ci_fresh_apply.sql` after `object_workspace_gap_rpcs.sql`**
+
+Find this block and insert the new step (renumber the trailing steps; keep `\ir`):
+```sql
+\echo '== 8/13  object_workspace_gap_rpcs.sql =='
+\ir object_workspace_gap_rpcs.sql
+\echo '== 8b/14 migration_permission_write_paths.sql  (SP-1 canonical-write auth; after RLS + workspace RPCs) =='
+\ir migration_permission_write_paths.sql
+\echo '== 9/13  ui_whitelabel_branding.sql  (defines api.is_platform_admin) =='
+\ir ui_whitelabel_branding.sql
+```
+
+- [ ] **Step 2: Add a CI test step in `.github/workflows/sql-fresh-apply.yml`** (after the "Smoke" step, before "Stop Supabase"):
+
+```yaml
+      - name: SP-1 structural assertions (canonical-write authorization)
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: psql "$DB_URL" -v ON_ERROR_STOP=1 -f "Base de donnée DLL et API/tests/test_sp1_canonical_write_auth.sql"
+```
+
+- [ ] **Step 3: Add the migration to the runbook manifest** — in `docs/SQL_ROLLOUT_RUNBOOK.md`, under "Fresh Database — Complete Ordered Manifest", insert after item 8:
+
+```markdown
+8b. `migration_permission_write_paths.sql` — **SP-1 canonical-write authorization** (additive `user_can_write_object_canonical` across the workspace gate + 23 write policies + `object.status` guard trigger). After the workspace RPCs (depends on `rls_policies.sql` helpers + the gate).
+```
+
+- [ ] **Step 4: Add the migration to both README quick-starts** — in `README.md` (after the `object_workspace_gap_rpcs.sql` line) and `Base de donnée DLL et API/README.md` (after its `object_workspace_gap_rpcs.sql` `\i` line):
+
+`README.md`:
+```bash
+# 5b. SP-1 canonical-write authorization (après les RPC workspace)
+psql -d votre_database -f "Base de donnée DLL et API/migration_permission_write_paths.sql"
+```
+`Base de donnée DLL et API/README.md`:
+```sql
+-- 5b) SP-1 autorisation d'écriture canonique (après les RPC workspace)
+\i migration_permission_write_paths.sql
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "Base de donnée DLL et API/ci_fresh_apply.sql" ".github/workflows/sql-fresh-apply.yml" "docs/SQL_ROLLOUT_RUNBOOK.md" "README.md" "Base de donnée DLL et API/README.md"
+git commit -m "chore(sql): add SP-1 migration to the fresh-apply manifest + CI gate"
+```
+
+---
+
+## Task 5: Update invariants and the decision log
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `bertel-tourism-ui/claude_brief/lot1_mapping_decisions.md`
+
+- [ ] **Step 1: Update the CLAUDE.md "Write-path authorization" invariant**
+
+Replace the existing block:
+```markdown
+### Write-path authorization (target — established by P0.2)
+Object write paths must enforce the Level-2 permission catalog (`api.user_has_permission`, `edit_org_enrichment`, `edit_canonical_when_publisher`, `publish_object`), not the legacy `is_object_owner` / `created_by` check. This is **not yet true**: as of 2026-06-02 the 22-section save RPCs gate only through `internal.workspace_assert_can_write_object` → `is_object_owner`, and object UPDATE RLS uses `created_by`. Until P0.2 lands, do NOT add new write paths that entrench the legacy owner-only model; new writes should consult the permission catalog so the cutover stays clean. Tracked in `lot1_mapping_decisions.md` §24 (P0.2 / S5).
+```
+with:
+```markdown
+### Write-path authorization
+Object canonical writes are authorized by `api.user_can_write_object_canonical(obj)` = `is_object_owner(obj) OR user_can_write_canonical(obj)` — the **single** predicate used by the workspace gate (`internal.workspace_assert_can_write_object`) and every canonical write policy (`object` UPDATE/DELETE + the `owner_*_write` child-table policies). It is **additive**: the legacy owner/superuser path is retained (removing it would brick the only seeded user — there are 0 permission grants yet). The permission path (`user_can_write_canonical` = publisher ORG + `edit_canonical_when_publisher`) becomes effective once SP-2 grants permissions. Publication status is NOT covered by canonical-write: `object.status` changes require `publish_object` via `api.rpc_publish_object`, enforced by `trg_guard_object_status_change`. Per-org `object_description` overlays remain the sole domain of `api.rpc_write_org_description` (§20). New write paths MUST consult `user_can_write_object_canonical` (or the appropriate `user_can_*` helper), never raw `is_object_owner`. Established by SP-1 (`migration_permission_write_paths.sql`); see `lot1_mapping_decisions.md` §24.
+```
+
+- [ ] **Step 2: Mark SP-1 done in §24** — under the SP‑1 bullet in `lot1_mapping_decisions.md` §24, append:
+```markdown
+    - **SP‑1 DONE (DDL written + CI-gated) 2026-06-02.** `migration_permission_write_paths.sql`: helper `api.user_can_write_object_canonical`, workspace gate rewired, 23 write policies substituted, `object_description` carve-out, `trg_guard_object_status_change` status guard. Additive → no live behavior change (0 grants). Structural test `tests/test_sp1_canonical_write_auth.sql` in the CI gate. **Behavioral positive/negative permission test deferred to SP‑2** (needs a grant + a second user).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md "bertel-tourism-ui/claude_brief/lot1_mapping_decisions.md"
+git commit -m "docs: establish write-path authorization invariant (SP-1) + log update"
+```
+
+---
+
+## Self-review (completed during planning)
+
+- **Spec coverage:** helper (§3.1) → Task 2.1; full RLS surface (§3.2) → Task 2.1 (all 23 enumerated); `object_description` carve-out (§3.3) → Task 2.1 + test; status guard (§3.4) → Task 2.1 (realized as a `user_can_publish_object` check rather than a txn flag — simpler, no edit to `rpc_publish_object`; same intent); migration/manifest/CI (§3.5) → Tasks 3–4; verification (§5) → Tasks 1/3 structural + no-regression, behavioral deferred to SP‑2; invariant → Task 5.
+- **Placeholder scan:** none — every policy is written out in full; no "similar to" references.
+- **Type/name consistency:** policy names match `rls_policies.sql` exactly (verified against source lines 936–1480, 1031–1039, 1693); helper/trigger/function names consistent across migration, test, CI, and invariant text.
+- **Refinement vs spec:** the status guard uses `NOT api.user_can_publish_object(NEW.id)` instead of a transaction-local flag — equivalent enforcement of "canonical-edit ≠ publish" with fewer moving parts and no change to `rpc_publish_object`. Noted in Task 2 comments.

--- a/docs/superpowers/plans/2026-06-02-sp2-permission-activation.md
+++ b/docs/superpowers/plans/2026-06-02-sp2-permission-activation.md
@@ -1,0 +1,251 @@
+# SP‑2 Permission Activation (convention + behavioral test) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lock the role→permission convention in the decision log and add a behavioral test that proves SP‑1's canonical-write authorization + status guard + team-note access rule end-to-end against a seeded multi-user fixture.
+
+**Architecture:** No schema, no DDL, no live grants (the model forbids a role→permission mechanism; an org-wide grant can't be walked back for a viewer). SP‑2 = (1) a documented convention admins apply per-user, (2) one transactional, self-rolling-back SQL test that seeds 3 synthetic non-superuser users (viewer/contributor/editor) and impersonates them via `request.jwt.claims` to assert the authorization booleans, the status guard, and the membership-based team-note rule. The test is added to the CI gate after the SP‑1 structural test.
+
+**Tech Stack:** PostgreSQL/Supabase RLS, `psql`, Supabase CLI local DB. Spec: `docs/superpowers/specs/2026-06-02-sp2-permission-activation-design.md`. Depends on SP‑1 (`migration_permission_write_paths.sql`) being in the applied manifest.
+
+**Execution prerequisite:** same as SP‑1 — a Supabase local DB with the full manifest (incl. the SP‑1 migration) applied; verification is CI-bound (no local Docker here). Local DB URL: `postgresql://postgres:postgres@127.0.0.1:54322/postgres`.
+
+---
+
+## File structure
+
+- **Modify** `bertel-tourism-ui/claude_brief/lot1_mapping_decisions.md` — add the SP‑2 convention (role→permission table + team-note rule + `write_crm_notes` disambiguation) under §24.
+- **Create** `Base de donnée DLL et API/tests/test_sp2_permission_behavior.sql` — the behavioral test (fixture + impersonated assertions, self-rolling-back).
+- **Modify** `.github/workflows/sql-fresh-apply.yml` — run the SP‑2 test after the SP‑1 test.
+
+---
+
+## Task 1: Record the convention in the decision log
+
+**Files:**
+- Modify: `bertel-tourism-ui/claude_brief/lot1_mapping_decisions.md`
+
+- [ ] **Step 1: Append the SP‑2 convention under the SP‑2 bullet in §24**
+
+Find the SP‑2 bullet (begins `- **SP‑2 — Permission activation (SQL/data).**`) and append this immediately after it:
+
+```markdown
+    - **SP‑2 DECIDED + DONE (convention + test) 2026-06-02.** No schema, no `org_permission` grants (org-wide can't be revoked per-viewer — no Level-3). Roles stay orthogonal to permissions (§2.4); the convention guides **per-user** grants (`rpc_grant_user_permission`) and SP‑4's pre-checked defaults.
+      **Role→permission convention** (admin grants per user by business role):
+      | Permission | viewer | contributor | editor |
+      |---|:--:|:--:|:--:|
+      | create_object, edit_canonical_when_publisher, edit_org_enrichment, edit_hours, edit_pricing, edit_gallery, attach_documents | | ✓ | ✓ |
+      | publish_object, validate_changes, manage_team_messages | | | ✓ |
+
+      Rationale: OTI is `publisher` of all objects, so editing OTI's catalog *is* canonical editing → contributor needs `edit_canonical_when_publisher`; the contributor/editor split (no-publish vs publish) is exactly SP‑1's status guard.
+      **Team notes ("information équipe") = `object_private_description`** — already enforced, membership-based: create = any active org member incl. `viewer` (`can_write_object_private_notes` = active membership); edit/archive = author OR same-ORG admin-role superior OR platform superuser (`can_manage_object_private_note`). NOT a granted permission. So a `viewer` writes team notes + edits own, but no canonical.
+      **Disambiguation:** `information équipe` = the membership-based `object_private_description` path. `write_crm_notes` / `manage_team_messages` gate the separate, not-yet-built CRM/team-messages module — they do NOT gate `object_private_description`.
+      Behavioral proof: `Base de donnée DLL et API/tests/test_sp2_permission_behavior.sql` (in the CI gate). Spec: `docs/superpowers/specs/2026-06-02-sp2-permission-activation-design.md`. Real grants deferred to SP‑5.
+```
+
+- [ ] **Step 2: Commit** *(skip if leaving git to the user — working tree only)*
+
+```bash
+git add "bertel-tourism-ui/claude_brief/lot1_mapping_decisions.md"
+git commit -m "docs(access): SP-2 role→permission convention + team-note access rule"
+```
+
+---
+
+## Task 2: Behavioral test
+
+**Files:**
+- Create: `Base de donnée DLL et API/tests/test_sp2_permission_behavior.sql`
+
+- [ ] **Step 1: Write the test**
+
+```sql
+-- test_sp2_permission_behavior.sql
+-- SP-2 behavioral test: proves SP-1 canonical-write authorization + status guard + the
+-- membership-based team-note rule, end-to-end, against a seeded multi-user fixture.
+-- Self-contained + transactional: everything is ROLLBACK'd, nothing persists.
+-- Run AFTER the full manifest INCLUDING migration_permission_write_paths.sql (SP-1).
+-- Against a DB without SP-1, it fails fast (api.user_can_write_object_canonical missing) — that is the red state.
+--
+-- WATCH-POINTS (may need a tweak on first CI run; the assertions' intent is stable):
+--   * auth.users minimal insert (only id is NOT NULL/no-default on this DB);
+--   * app_user_profile.role value 'tourism_agent' must be a non-superuser role;
+--   * plpgsql SET LOCAL ROLE + subtransaction exception mechanics;
+--   * object id format if a CHECK constraint exists (explicit test ids used).
+\set ON_ERROR_STOP on
+BEGIN;
+
+DO $$
+DECLARE
+  v_org         text := 'ORGRUN9999999991';
+  v_obj         text := 'HOTRUN9999999991';
+  v_pub_role    uuid;
+  v_view_uid    uuid := '00000000-0000-4000-a000-0000000000a1';
+  v_contrib_uid uuid := '00000000-0000-4000-a000-0000000000a2';
+  v_editor_uid  uuid := '00000000-0000-4000-a000-0000000000a3';
+  v_m_view uuid; v_m_contrib uuid; v_m_editor uuid;
+  v_note_view uuid;
+  v_rc integer;
+BEGIN
+  -- ---------- Fixture (as postgres; RLS bypassed for setup) ----------
+  SELECT id INTO v_pub_role FROM ref_org_role WHERE code = 'publisher';
+
+  INSERT INTO object (id, object_type, name) VALUES
+    (v_org, 'ORG', 'SP2 Test Org'),
+    (v_obj, 'HOT', 'SP2 Test Hotel');
+  INSERT INTO object_org_link (object_id, org_object_id, role_id) VALUES (v_obj, v_org, v_pub_role);
+
+  INSERT INTO auth.users (id) VALUES (v_view_uid), (v_contrib_uid), (v_editor_uid);
+  INSERT INTO app_user_profile (id, role) VALUES
+    (v_view_uid, 'tourism_agent'), (v_contrib_uid, 'tourism_agent'), (v_editor_uid, 'tourism_agent');
+
+  INSERT INTO user_org_membership (user_id, org_object_id, is_active) VALUES (v_view_uid,    v_org, TRUE) RETURNING id INTO v_m_view;
+  INSERT INTO user_org_membership (user_id, org_object_id, is_active) VALUES (v_contrib_uid, v_org, TRUE) RETURNING id INTO v_m_contrib;
+  INSERT INTO user_org_membership (user_id, org_object_id, is_active) VALUES (v_editor_uid,  v_org, TRUE) RETURNING id INTO v_m_editor;
+
+  INSERT INTO user_org_business_role (membership_id, role_id, is_active)
+    SELECT v_m_view,    id, TRUE FROM ref_org_business_role WHERE code = 'viewer';
+  INSERT INTO user_org_business_role (membership_id, role_id, is_active)
+    SELECT v_m_contrib, id, TRUE FROM ref_org_business_role WHERE code = 'contributor';
+  INSERT INTO user_org_business_role (membership_id, role_id, is_active)
+    SELECT v_m_editor,  id, TRUE FROM ref_org_business_role WHERE code = 'editor';
+
+  -- editor also holds an org_admin admin role (to edit/archive ANY team note)
+  INSERT INTO user_org_admin_role (membership_id, role_id, is_active)
+    SELECT v_m_editor, id, TRUE FROM ref_org_admin_role WHERE code = 'org_admin';
+
+  -- per-convention user_permission grants (direct insert; bypasses the anti-self RPC checks)
+  INSERT INTO user_permission (user_id, permission_id, is_active, granted_by, granted_at, created_at, updated_at)
+    SELECT v_contrib_uid, id, TRUE, v_editor_uid, NOW(), NOW(), NOW()
+    FROM ref_permission WHERE code IN
+      ('create_object','edit_canonical_when_publisher','edit_org_enrichment','edit_hours','edit_pricing','edit_gallery','attach_documents');
+  INSERT INTO user_permission (user_id, permission_id, is_active, granted_by, granted_at, created_at, updated_at)
+    SELECT v_editor_uid, id, TRUE, v_editor_uid, NOW(), NOW(), NOW()
+    FROM ref_permission WHERE code IN
+      ('create_object','edit_canonical_when_publisher','edit_org_enrichment','edit_hours','edit_pricing','edit_gallery','attach_documents','publish_object','validate_changes','manage_team_messages');
+
+  -- a note authored by the viewer (set up as postgres so we can test edit-by-others)
+  INSERT INTO object_private_description (object_id, org_object_id, created_by_user_id, audience, body)
+    VALUES (v_obj, v_org, v_view_uid, 'private', 'viewer note') RETURNING id INTO v_note_view;
+
+  -- ---------- Assertions: authorization helpers (SECURITY DEFINER read auth.uid() from the GUC) ----------
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_view_uid,    'role','authenticated')::text, true);
+  ASSERT api.user_can_write_object_canonical(v_obj) = FALSE, 'viewer must NOT write canonical';
+
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_contrib_uid, 'role','authenticated')::text, true);
+  ASSERT api.user_can_write_object_canonical(v_obj) = TRUE,  'contributor MUST write canonical';
+  ASSERT api.user_can_publish_object(v_obj)        = FALSE,  'contributor must NOT publish';
+
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_editor_uid,  'role','authenticated')::text, true);
+  ASSERT api.user_can_write_object_canonical(v_obj) = TRUE,  'editor MUST write canonical';
+  ASSERT api.user_can_publish_object(v_obj)        = TRUE,   'editor MUST publish';
+
+  -- ---------- Status guard: contributor (canonical, no publish) cannot change status ----------
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_contrib_uid, 'role','authenticated')::text, true);
+  BEGIN
+    SET LOCAL ROLE authenticated;
+    UPDATE object SET status = 'published' WHERE id = v_obj;
+    RAISE EXCEPTION 'STATUS GUARD FAILED: contributor changed status without publish_object';
+  EXCEPTION
+    WHEN insufficient_privilege THEN NULL;  -- expected: SQLSTATE 42501 from trg_guard_object_status_change
+  END;
+  RESET ROLE;
+
+  -- editor CAN publish (has publish_object): RLS allows + guard passes
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_editor_uid, 'role','authenticated')::text, true);
+  SET LOCAL ROLE authenticated;
+  UPDATE object SET status = 'published' WHERE id = v_obj;
+  GET DIAGNOSTICS v_rc = ROW_COUNT;
+  RESET ROLE;
+  ASSERT v_rc = 1, 'editor MUST be able to publish (1 row)';
+
+  -- ---------- Team notes: membership create, edit-own, admin-edit-any ----------
+  -- viewer creates a note (membership) and edits OWN
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_view_uid, 'role','authenticated')::text, true);
+  SET LOCAL ROLE authenticated;
+  INSERT INTO object_private_description (object_id, org_object_id, created_by_user_id, audience, body)
+    VALUES (v_obj, v_org, v_view_uid, 'private', 'viewer second note');
+  UPDATE object_private_description SET body = 'viewer edited own' WHERE id = v_note_view;
+  GET DIAGNOSTICS v_rc = ROW_COUNT;
+  RESET ROLE;
+  ASSERT v_rc = 1, 'viewer MUST edit own note';
+
+  -- contributor cannot edit the viewer's note (not author, not admin) -> RLS denies (0 rows)
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_contrib_uid, 'role','authenticated')::text, true);
+  SET LOCAL ROLE authenticated;
+  UPDATE object_private_description SET body = 'contrib tries' WHERE id = v_note_view;
+  GET DIAGNOSTICS v_rc = ROW_COUNT;
+  RESET ROLE;
+  ASSERT v_rc = 0, 'contributor must NOT edit another members note';
+
+  -- editor (org_admin) edits ANY note
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', v_editor_uid, 'role','authenticated')::text, true);
+  SET LOCAL ROLE authenticated;
+  UPDATE object_private_description SET body = 'admin edited' WHERE id = v_note_view;
+  GET DIAGNOSTICS v_rc = ROW_COUNT;
+  RESET ROLE;
+  ASSERT v_rc = 1, 'org_admin editor MUST edit any note';
+
+  RAISE NOTICE 'SP-2 behavioral assertions passed.';
+END$$;
+
+ROLLBACK;
+```
+
+- [ ] **Step 2: Run it against the full-manifest DB — expect PASS**
+
+Run:
+```bash
+psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -v ON_ERROR_STOP=1 \
+  -f "Base de donnée DLL et API/tests/test_sp2_permission_behavior.sql"
+```
+Expected: `NOTICE: SP-2 behavioral assertions passed.`, exit 0. (Against a DB missing the SP‑1 migration it errors on `api.user_can_write_object_canonical` — the red state.) If a watch-point trips (auth.users columns, role value, role/exception mechanics), fix inline and re-run — the assertions stay; only the fixture/mechanics adjust.
+
+- [ ] **Step 3: Commit** *(skip if leaving git to the user)*
+
+```bash
+git add "Base de donnée DLL et API/tests/test_sp2_permission_behavior.sql"
+git commit -m "test(sql): SP-2 behavioral test — canonical-write auth, status guard, team-note rule"
+```
+
+---
+
+## Task 3: Add the test to the CI gate
+
+**Files:**
+- Modify: `.github/workflows/sql-fresh-apply.yml`
+
+- [ ] **Step 1: Add an SP‑2 step after the SP‑1 step**
+
+Find the SP‑1 step and insert the SP‑2 step immediately after it (before "Stop Supabase"):
+
+```yaml
+      - name: SP-2 behavioral test (permission convention + status guard + team notes)
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: psql "$DB_URL" -v ON_ERROR_STOP=1 -f "Base de donnée DLL et API/tests/test_sp2_permission_behavior.sql"
+```
+
+- [ ] **Step 2: Validate the YAML**
+
+Run:
+```bash
+node -e "const y=require('./bertel-tourism-ui/node_modules/js-yaml');const fs=require('fs');const d=y.load(fs.readFileSync('.github/workflows/sql-fresh-apply.yml','utf8'));console.log('OK steps:',d.jobs['fresh-apply'].steps.length)"
+```
+Expected: `OK steps: 9`.
+
+- [ ] **Step 3: Commit** *(skip if leaving git to the user)*
+
+```bash
+git add ".github/workflows/sql-fresh-apply.yml"
+git commit -m "ci(sql): run SP-2 behavioral test in the fresh-apply gate"
+```
+
+---
+
+## Self-review (completed during planning)
+
+- **Spec coverage:** convention table (spec §3) → Task 1; team-note rule + disambiguation (spec §4) → Task 1 + test assertions; behavioral test fixture + assertions (spec §5) → Task 2 (viewer/contributor/editor; helper booleans; status guard; note create/edit-own/admin-edit-any all asserted); CI verification (spec §6) → Task 3. No `org_permission` grant, no schema (spec §2) — honored (none present).
+- **Placeholder scan:** none — full convention markdown and full test SQL provided; watch-points are flagged uncertainties about the *environment*, not unfinished plan content.
+- **Type/name consistency:** permission codes, role codes (`viewer`/`contributor`/`editor`, `org_admin`, `publisher`), helper names (`user_can_write_object_canonical`, `user_can_publish_object`), and column names match SP‑1's migration and the verified schema (auth.users/app_user_profile/user_org_membership/user_org_business_role/user_org_admin_role/object/object_org_link/object_private_description required columns confirmed via information_schema).
+- **Red state:** documented — the test errors on the missing helper if SP‑1 isn't applied; green once the full manifest (incl. SP‑1) is applied. It is an acceptance test for SP‑1's behavior, which SP‑1's spec deferred here.

--- a/docs/superpowers/plans/2026-06-02-sp2-permission-activation.md
+++ b/docs/superpowers/plans/2026-06-02-sp2-permission-activation.md
@@ -95,9 +95,15 @@ BEGIN
     (v_obj, 'HOT', 'SP2 Test Hotel');
   INSERT INTO object_org_link (object_id, org_object_id, role_id) VALUES (v_obj, v_org, v_pub_role);
 
-  INSERT INTO auth.users (id) VALUES (v_view_uid), (v_contrib_uid), (v_editor_uid);
+  -- auth.users has trigger on_auth_user_created_app_user_profile which AUTO-CREATES the profile;
+  -- insert users (unique emails), then UPSERT the role to non-superuser (ON CONFLICT absorbs the trigger row).
+  INSERT INTO auth.users (id, email) VALUES
+    (v_view_uid,    'sp2_viewer@test.local'),
+    (v_contrib_uid, 'sp2_contributor@test.local'),
+    (v_editor_uid,  'sp2_editor@test.local');
   INSERT INTO app_user_profile (id, role) VALUES
-    (v_view_uid, 'tourism_agent'), (v_contrib_uid, 'tourism_agent'), (v_editor_uid, 'tourism_agent');
+    (v_view_uid, 'tourism_agent'), (v_contrib_uid, 'tourism_agent'), (v_editor_uid, 'tourism_agent')
+  ON CONFLICT (id) DO UPDATE SET role = EXCLUDED.role;
 
   INSERT INTO user_org_membership (user_id, org_object_id, is_active) VALUES (v_view_uid,    v_org, TRUE) RETURNING id INTO v_m_view;
   INSERT INTO user_org_membership (user_id, org_object_id, is_active) VALUES (v_contrib_uid, v_org, TRUE) RETURNING id INTO v_m_contrib;

--- a/docs/superpowers/specs/2026-06-02-sp1-canonical-write-auth-design.md
+++ b/docs/superpowers/specs/2026-06-02-sp1-canonical-write-auth-design.md
@@ -1,0 +1,148 @@
+# SP‑1 — Canonical-write authorization (design spec)
+
+- **Date:** 2026-06-02
+- **Status:** approved (design), pending spec review
+- **Part of:** P0.2 "full multi-role enablement" (see `bertel-tourism-ui/claude_brief/lot1_mapping_decisions.md` §24). SP‑1 is the backend foundation; SP‑2..SP‑5 follow.
+- **Scope:** backend SQL only (RLS policies, helper function, one trigger, one migration file). No frontend, no grants, no UI.
+
+---
+
+## 1. Context & problem
+
+The 22-section object editor authorizes writes two ways, both keyed on the **legacy** `api.is_object_owner(object_id)`:
+- the safe-write RPCs gate through `internal.workspace_assert_can_write_object` (owner-only);
+- the many direct PostgREST table writes are governed by `owner_write_*` RLS policies (owner-only) and the `object` UPDATE/DELETE policies (`auth.uid() = created_by`).
+
+The Level‑2 permission model is **defined** (`api.user_has_permission`, `api.user_can_write_canonical`, `api.user_can_write_enrichment`, `api.user_can_publish_object`) but is **not** the enforcement path for editor writes. Multi-role ORG contributors therefore cannot edit.
+
+**Live-state finding (2026-06-02, verified read-only):** the catalog is fully seeded (`ref_org_role` = publisher/contributor/reader; all 5 content permissions; helpers defined), but `org_permission` and `user_permission` are **empty (0 grants)** and there is **1 user** (the OTI du Sud platform superuser; all 837 `object_org_link` rows are `publisher`). Consequently `api.user_has_permission(...)` returns FALSE for everyone today, and editing works **only** because `is_object_owner` returns TRUE for the superuser via `is_platform_superuser()`.
+
+**Hard constraint:** the change must be **additive** (`is_object_owner OR user_can_write_canonical`). Replacing `is_object_owner` would lock out the only user — §2.6 of the access-control master plan forbids any admin/superuser bypass of `user_has_permission`, so with zero grants a permission-only rule authorizes no one.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Make the Level‑2 canonical-write permission a *valid path* to write an object's canonical data, alongside the legacy owner path, everywhere editor writes are authorized (workspace gate + RLS).
+- Zero regression: the existing superuser keeps full write access; read-only ORG members and `contributor`-role ORGs still cannot write canonical.
+- Preserve the publish boundary: holding `edit_canonical_when_publisher` must NOT confer the ability to change publication status (that needs `publish_object`).
+- Preserve the §20 invariant: `rpc_write_org_description` remains the sole writer of per-org `object_description` overlay rows.
+
+**Non-goals (other sub-projects / unchanged)**
+- Granting any permission to any ORG/user → **SP‑2**.
+- Frontend `canDirectWrite` relaxation → **SP‑3**.
+- Admin UI / user onboarding → **SP‑4 / SP‑5**.
+- The org-enrichment write path (`rpc_write_org_description`, gated by `user_can_write_enrichment`) — unchanged.
+- The publish path (`rpc_publish_object`, gated by `user_can_publish_object`) — unchanged except for the status-guard flag (below).
+
+## 3. Design
+
+### 3.1 One authorization helper (single source of truth)
+
+```sql
+CREATE OR REPLACE FUNCTION api.user_can_write_object_canonical(p_object_id text)
+RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, api, auth
+AS $$
+  SELECT api.is_object_owner(p_object_id)          -- legacy actor-owner + service_role/admin + platform superuser
+      OR api.user_can_write_canonical(p_object_id); -- publisher ORG member holding edit_canonical_when_publisher
+$$;
+-- REVOKE FROM PUBLIC, anon; GRANT TO authenticated, service_role;
+```
+
+`api.user_can_write_canonical` already encodes "Level‑2 `edit_canonical_when_publisher` AND the active ORG is `publisher` on the object". `is_object_owner` already folds in `service_role`/`admin` and `is_platform_superuser`. The OR is the whole rule.
+
+### 3.2 Apply the helper across the canonical write surface
+
+Substitute `api.is_object_owner(<id>)` → `api.user_can_write_object_canonical(<id>)` in every **write** policy currently keyed on `is_object_owner`, and in the workspace gate. The complete surface (enumerated from `rls_policies.sql`, exact lines pinned in the implementation plan):
+
+- **Workspace gate:** `internal.workspace_assert_can_write_object` (`object_workspace_safe_write_rpcs.sql:77`).
+- **`object` table:** `owner_update_object` (UPDATE) and `owner_delete_object` (DELETE) — currently `auth.uid() = created_by`; becomes `created_by OR user_can_write_object_canonical(id)`. (INSERT stays on `user_can_create_object()`, unchanged.)
+- **`owner_write_*` child-table policies (`FOR ALL USING`):** `object_location`, `object_place`, `contact_channel`, `media`, `object_legal`, `object_discount`, `object_group_policy`, `object_price` (+ `object_price_period` via parent), `object_menu` (+ `object_menu_item`, `_dietary_tag`, `_allergen`, `_cuisine_type`, `_media` via parents), `object_meeting_room` (+ `meeting_room_equipment`), `object_pet_policy`, `object_fma_occurrence`, `object_iti_stage_media` (via stage).
+- **`owner_object_membership_write`** on `object_membership` (`rls_policies.sql:1693`, the §17 "Rattachements" write path): `auth.role() IN ('service_role','admin') OR is_object_owner(COALESCE(object_id, org_object_id))` — substitute the `is_object_owner` term, preserving the `auth.role()` branch and the `COALESCE` (the COALESCE handles ORG-scoped memberships, where the canonical check then applies to the ORG object itself).
+
+Scope confirmation (checked `rls_policies.sql`): the substitution touches canonical object tables only. The adjacent `incident_report` / `publication` / `audit_*` write policies are `service_role`/`admin`-only and are NOT keyed on `is_object_owner`, so SP‑1 does not touch the CRM / moderation / audit / publication surface.
+
+Notes:
+- These are `FOR ALL USING (...)` policies, so the substitution broadens **read and write** alike for canonical writers. That is acceptable and desirable — a canonical writer should also read the rows it edits. Public reads still flow through each table's existing `FOR SELECT` policy (public `USING (true)` on most child tables; visibility-gated on `object_description`); SP‑1 adds only canonical-writer read/write and exposes nothing new to `anon`.
+- **Do NOT** change: the `api.is_object_owner` function definition itself, the read-only/`FOR SELECT` policies, the admin/service_role `FOR ALL` policies, or the `GRANT`s.
+
+### 3.3 `object_description` — special case (preserve §20)
+
+`object_description` holds canonical rows (`org_object_id IS NULL`) and per-org overlay rows, and `rpc_write_org_description` (SECURITY DEFINER) is the sole legitimate overlay writer. To add canonical writers **without** letting them touch other orgs' overlays via RLS:
+
+```sql
+-- owner_write_description becomes:
+USING (
+  api.is_object_owner(object_id)                                   -- legacy owner: unchanged (full)
+  OR (api.user_can_write_canonical(object_id) AND org_object_id IS NULL) -- new path: canonical rows only
+)
+```
+The new canonical path is constrained to `org_object_id IS NULL`; overlays remain the RPC's domain.
+
+### 3.4 Protect `object.status` (canonical-edit ≠ publish)
+
+Broadening the `object` UPDATE policy would otherwise let an `edit_canonical_when_publisher`-only user change `status` directly (PostgREST UPDATE), bypassing the `publish_object` permission. Guard it:
+
+```sql
+CREATE OR REPLACE FUNCTION api.guard_object_status_change() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, api, auth AS $$
+BEGIN
+  IF NEW.status IS DISTINCT FROM OLD.status
+     AND auth.role() NOT IN ('service_role','admin')
+     AND NOT api.is_platform_superuser()
+     AND COALESCE(current_setting('app.allow_status_change', true), '') <> '1'
+  THEN
+    RAISE EXCEPTION 'Object status changes must go through rpc_publish_object (publish_object permission required)'
+      USING ERRCODE = '42501';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_guard_object_status_change
+  BEFORE UPDATE OF status ON object
+  FOR EACH ROW EXECUTE FUNCTION api.guard_object_status_change();
+```
+
+`rpc_publish_object` (the only legitimate status path) sets the flag before its UPDATE:
+```sql
+PERFORM set_config('app.allow_status_change', '1', true);  -- true = transaction-local
+```
+`service_role`/`admin`/platform-superuser remain exempt (platform ops, migrations, the existing admin `FOR ALL` policy). This also hardens the pre-existing publish path against accidental direct status edits.
+
+### 3.5 Migration, manifest, verification
+
+- New idempotent file **`Base de donnée DLL et API/migration_permission_write_paths.sql`** (`CREATE OR REPLACE` for the helper/trigger fn; `DROP POLICY IF EXISTS` + `CREATE POLICY` for each policy; `DROP TRIGGER IF EXISTS` + `CREATE TRIGGER`; transaction-wrapped). Reversible: a documented down-migration restores the `is_object_owner` predicates and drops the trigger/helper.
+- **Apply order:** after `rls_policies.sql` (depends on the permission helpers) and after `object_workspace_safe_write_rpcs.sql` (the gate). Add it to the manifest in `docs/SQL_ROLLOUT_RUNBOOK.md`, the two README quick-starts, and `ci_fresh_apply.sql` (step between RLS/RPCs and branding) — so the CI fresh-apply gate covers it.
+- `rpc_publish_object` edit lives in `api_views_functions.sql` (its current home) so the manifest ordering is unaffected.
+
+## 4. Authorization semantics after SP‑1 (before any SP‑2 grant)
+
+| Caller | Canonical write (name, location, media, pricing, …) | `object.status` change |
+|---|---|---|
+| Platform superuser / service_role | ✅ (via `is_object_owner`) | ✅ (trigger-exempt) |
+| Actor-owner (`actor_object_role.is_primary`) | ✅ (via `is_object_owner`) | ❌ (must use publish RPC) |
+| Publisher-ORG member with `edit_canonical_when_publisher` | ✅ (via `user_can_write_canonical`) — **inert until SP‑2 grants it** | ❌ unless also `publish_object` (via RPC) |
+| Contributor-ORG member / read-only member | ❌ | ❌ |
+
+Net behavior change on live **today**: none (0 grants, 1 superuser) — SP‑1 only opens the path.
+
+## 5. Verification
+
+- **CI fresh-apply gate** proves the migration applies clean in dependency order on a blank Supabase DB.
+- **No-regression:** confirm the superuser still writes (read-only probe of policy presence + a scratch/branch write test).
+- **Positive/negative permission test (lands with SP‑2, once a grant + a second user exist):** a publisher-ORG user *with* `edit_canonical_when_publisher` can write canonical and cannot change status; a user *without* it cannot write.
+- **Status guard:** a direct PostgREST `UPDATE object SET status=...` by a non-superuser is rejected; `rpc_publish_object` still succeeds.
+
+## 6. Risks & mitigations
+
+- **Lock-out risk** → mitigated by the additive OR and `is_object_owner` retaining the superuser path; verified no-regression.
+- **Status self-publish** → mitigated by the `BEFORE UPDATE OF status` trigger + RPC flag.
+- **Overlay clobber (§20)** → mitigated by the `org_object_id IS NULL` predicate on `object_description`.
+- **Performance:** the helper runs per affected row on writes (low volume) and on reads of the broadened `FOR ALL` tables; predicates are the same membership/`object_org_link` lookups already used by `can_read_extended`. Acceptable; revisit only if a hot read path on these child tables regresses.
+- **Missed policy:** the implementation plan must enumerate every `is_object_owner` write usage from `rls_policies.sql` and confirm none is left on the legacy predicate (except the function definition and intentional read/admin policies).
+
+## 7. Rollback
+
+Re-run the prior `rls_policies.sql` definitions (restore `is_object_owner` predicates), `DROP TRIGGER trg_guard_object_status_change`, `DROP FUNCTION api.guard_object_status_change`, `DROP FUNCTION api.user_can_write_object_canonical`, and revert the `rpc_publish_object` flag line. No data changes, so rollback is pure DDL.

--- a/docs/superpowers/specs/2026-06-02-sp2-permission-activation-design.md
+++ b/docs/superpowers/specs/2026-06-02-sp2-permission-activation-design.md
@@ -1,0 +1,103 @@
+# SP‑2 — Permission activation: convention + behavioral test (design spec)
+
+- **Date:** 2026-06-02
+- **Status:** approved (design), pending spec review
+- **Part of:** P0.2 "full multi-role enablement" (see `lot1_mapping_decisions.md` §24). Depends on SP‑1 (`migration_permission_write_paths.sql`). Precedes SP‑3/SP‑4/SP‑5.
+- **Scope:** documentation (a role→permission convention) + one behavioral test. **No schema, no DDL, no production grants.**
+
+---
+
+## 1. Context & problem
+
+SP‑1 wired the canonical-write permission path additively but it is **inert**: `org_permission` and `user_permission` are empty, and only the OTI superuser exists. SP‑2 "activates" the model — but the activation is constrained by locked decisions:
+
+- **Roles confer no permissions (master plan §2.4, §D1).** Business roles `viewer`(10)/`contributor`(20)/`editor`(30) are orthogonal to permissions. A role→permission mapping must NOT be built. Permissions come only from `org_permission` (all members) or `user_permission` (one user).
+- **No Level‑3 revoke exists.** An `org_permission` grant cannot be selectively walked back for a `viewer`. So org-wide content-edit grants would give every member edit rights, breaking role differentiation. → **Content-edit permissions are granted per-user, never org-wide.**
+- **Only the superuser exists today.** There is no one to grant to yet; real per-user grants happen at onboarding (SP‑5).
+
+Therefore SP‑2 cannot meaningfully "grant OTI permissions" now. What it CAN do: lock the **convention** that admins will apply per-user (and that the SP‑4 admin UI will pre-check as suggested defaults), and build the **behavioral test** that proves SP‑1 + the grant path work end-to-end.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Lock a documented role→permission convention (which permissions an admin grants for each business role).
+- Document the **"information équipe" (team notes)** access rule and confirm it is already enforced by the existing `object_private_description` RLS.
+- Build a behavioral test proving: granted users can write canonical; `contributor` (canonical but no publish) is blocked from status changes by SP‑1's guard; `editor` can publish; `viewer` writes no canonical but CAN create team notes and edit only their own.
+
+**Non-goals (other sub-projects / unchanged)**
+- Real production permission grants → **SP‑5** (needs real users).
+- The admin UI that applies the convention → **SP‑4**.
+- The CRM / team-messages module (`write_crm_notes`, `manage_team_messages`) → P2.
+- Any schema change, any `org_permission` grant, any role→permission mechanism (forbidden by §2.4).
+
+## 3. The role→permission convention (authoritative)
+
+Permissions an admin grants **per user** (`user_permission`) based on the user's business role. This is a CONVENTION, not an enforced mechanism — `user_has_permission` still resolves only explicit grants; the convention guides admins and pre-fills the SP‑4 UI.
+
+| Permission (`ref_permission.code`) | `viewer` | `contributor` | `editor` |
+|---|:--:|:--:|:--:|
+| `create_object` | | ✓ | ✓ |
+| `edit_canonical_when_publisher` | | ✓ | ✓ |
+| `edit_org_enrichment` | | ✓ | ✓ |
+| `edit_hours` | | ✓ | ✓ |
+| `edit_pricing` | | ✓ | ✓ |
+| `edit_gallery` | | ✓ | ✓ |
+| `attach_documents` | | ✓ | ✓ |
+| `publish_object` | | | ✓ |
+| `validate_changes` | | | ✓ |
+| `manage_team_messages` | | | ✓ |
+| `write_crm_notes` | | (see §4) | (see §4) |
+
+**Rationale for `contributor` holding `edit_canonical_when_publisher`:** OTI du Sud is the `publisher` of all 837 objects, so editing OTI's own catalog *is* canonical editing (`edit_canonical_when_publisher` is publisher-gated). Without it, a contributor could not edit OTI's catalog at all. `edit_org_enrichment` is included for the future case where OTI enriches another org's published object (none today). The `contributor`/`editor` split is precisely "can write canonical, cannot publish" vs "can also publish/validate" — which exercises SP‑1's status guard.
+
+This convention is recorded in `lot1_mapping_decisions.md` (SP‑2 section) and is the source of truth for SP‑4's pre-checked defaults.
+
+## 4. "Information équipe" (team notes) — access rule (already enforced)
+
+Team notes are the per-object internal notes stored in `object_private_description`. The required rule — **create = any active org member (incl. `viewer`); edit/archive = author, or an admin-role superior in the same ORG, or platform superuser** — is **already enforced** by existing RLS, no change needed:
+
+- INSERT `org_insert_private_description` (rls:953): `can_write_object_private_notes(object_id)` (= `current_user_org_id() IS NOT NULL`, i.e. any active member) AND `org_object_id = current_user_org_id()` AND `created_by_user_id = auth.uid()` AND `audience = 'private'`.
+- UPDATE/DELETE `manage_update/delete_private_description` (rls:968–981): `can_manage_object_private_note` / `can_delete_object_private_note` = author OR same-ORG hierarchical superior (admin role) OR platform superuser.
+
+**Consequences for SP‑2:**
+- The convention treats team-note create/edit as **membership + author + admin-role based**, NOT a granted permission. A `viewer` therefore CAN create team notes and edit their own — `viewer` is "no catalog write," not "no write at all."
+- **Disambiguation (documented, not changed here):** "information équipe" = the membership-based `object_private_description` path. The `write_crm_notes` permission and `manage_team_messages` permission gate the separate, not-yet-built CRM / team-messages module — they do NOT gate `object_private_description`. SP‑2 records this so the two paths aren't conflated later.
+
+## 5. Behavioral test
+
+A new transactional, self-rolling-back test `Base de donnée DLL et API/tests/test_sp2_permission_behavior.sql`, added to the CI gate after the SP‑1 structural test. It seeds a self-contained fixture and impersonates each user via `request.jwt.claims` (`set local role authenticated; set local request.jwt.claims = '{"sub":"…","role":"authenticated"}'`), then `ROLLBACK`s.
+
+**Fixture (all inside the test transaction):**
+- 1 test ORG object (`object_type='ORG'`) and 1 test object published by it (`object_org_link` role `publisher`).
+- 3 synthetic users in `auth.users` + `app_user_profile` with role **`tourism_agent`** (NOT superuser — so `is_object_owner` does not short-circuit and the permission path is what's exercised), each with an active `user_org_membership` to the test ORG and a `user_org_business_role`:
+  - **U_view** (`viewer`): no `user_permission` grants.
+  - **U_contrib** (`contributor`): granted `edit_canonical_when_publisher` (+ the rest of the contributor set), NOT `publish_object`.
+  - **U_editor** (`editor`): granted `edit_canonical_when_publisher` + `publish_object` (+ editor set); also given an `org_admin` admin role to exercise admin-edits-any-note.
+
+**Assertions (impersonated):**
+| As | `user_can_write_object_canonical(obj)` | `user_can_publish_object(obj)` | direct `UPDATE object SET status` | create private note | edit own note | edit another's note |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|
+| U_view | FALSE | FALSE | n/a (RLS denies) | ✓ | ✓ | ✗ |
+| U_contrib | TRUE | FALSE | **rejected (status guard)** | ✓ | ✓ | ✗ |
+| U_editor | TRUE | TRUE | allowed | ✓ | ✓ | ✓ (admin role) |
+
+- Boolean helper checks are asserted directly (deterministic).
+- The status-guard rejection is asserted inside a `BEGIN … EXCEPTION WHEN OTHERS` sub-block (expecting SQLSTATE 42501) so the failure is caught and asserted, not fatal.
+- Note: an RLS-denied UPDATE affects 0 rows rather than raising; the note/status assertions account for this (check `ROW_COUNT` / catch the trigger exception as appropriate).
+
+This closes SP‑1's deferred behavioral verification.
+
+## 6. Verification
+
+- CI gate runs `test_sp2_permission_behavior.sql` against the fresh Supabase DB after the manifest + SP‑1 test.
+- No live change: SP‑2 adds documentation + a test only; it grants nothing on live.
+
+## 7. Risks & mitigations
+
+- **Fixture correctness** (seeding `auth.users`, profiles, memberships, roles, grants with valid FKs/constraints; the object-id generation trigger) — highest risk; mitigated by the self-rolling-back transaction and the CI red→green loop (first run may need a tweak, like SP‑1's test).
+- **Convention drift:** the convention is documentation; nothing enforces that admins follow it. Mitigated by SP‑4 pre-checking these defaults in the grant UI. Acceptable — the model intentionally keeps roles and permissions decoupled.
+- **`write_crm_notes` ambiguity:** flagged and documented (§4); not resolved here (belongs to the CRM/team-messages module build).
+
+## 8. Out of scope / deferred
+
+Real per-user grants (SP‑5); the admin grant UI (SP‑4); the CRM/team-messages module; any `org_permission` grant; any schema or role→permission mechanism.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,12 @@
+# Minimal Supabase CLI config — used by the SQL fresh-apply CI gate
+# (.github/workflows/sql-fresh-apply.yml). The CLI fills defaults for any
+# section not specified here. Regenerate/extend with `supabase init` if a
+# newer CLI requires more fields.
+project_id = "bertel"
+
+[db]
+# Default local connection: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+port = 54322
+shadow_port = 54320
+# Match live PROD (17.6) so the fresh-apply test runs on the same major version.
+major_version = 17


### PR DESCRIPTION
## Summary
- **P0.1 — deploy integrity:** complete fresh-apply manifest (`ci_fresh_apply.sql`, runbook, READMEs) + a GitHub Actions gate (`sql-fresh-apply.yml`, Supabase CLI) that builds a blank DB from the documented order and runs the SQL test suite. Proves the repo can reproduce the live schema.
- **SP-1 — canonical-write authorization:** `migration_permission_write_paths.sql` — additive `api.user_can_write_object_canonical` (= `is_object_owner OR user_can_write_canonical`) substituted into the workspace gate + 24 object/child-table write policies, an `object.status` guard trigger (canonical-edit ≠ publish), and `save_object_version → SECURITY DEFINER`.
- **SP-2 — permission activation:** role→permission convention (docs) + a behavioral test (viewer/contributor/editor fixture).

## The gate caught 4 pre-existing reproducibility bugs
(the repo could not build a fresh DB before): `rls_policies.sql` forward-references; a `migration_legal_siret_canonical` `UPDATE…FROM` plan error; the SP-2 fixture trigger collision; and **`save_object_version` being `SECURITY INVOKER`** — which silently broke object editing for every authenticated (non-service-role) user on live.

## Test plan
- CI "SQL fresh-apply gate" is **green** (run 26863975925): manifest applies + SP-1 structural test + SP-2 behavioral test all pass on a fresh Supabase DB.
- SP-1 migration has been **applied to live PROD** (`sp1_canonical_write_paths`) and verified; additive (inert until permissions are granted), and it fixes the `save_object_version` editing bug immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)