### PR TITLE
SP-1b: complete canonical-write coverage for editor-write tables

### DIFF
--- a/.github/workflows/sql-fresh-apply.yml
+++ b/.github/workflows/sql-fresh-apply.yml
@@ -79,6 +79,11 @@ jobs:
           DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
         run: psql "$DB_URL" -v ON_ERROR_STOP=1 -f "Base de donnée DLL et API/tests/test_sp1_canonical_write_auth.sql"
 
+      - name: SP-1b coverage assertions (every editor-write table is canonical-covered)
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: psql "$DB_URL" -v ON_ERROR_STOP=1 -f "Base de donnée DLL et API/tests/test_sp1b_canonical_coverage.sql"
+
       - name: SP-2 behavioral test (permission convention + status guard + team notes)
         env:
           DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres

--- a/Base de donnée DLL et API/README.md
+++ b/Base de donnée DLL et API/README.md
@@ -77,6 +77,8 @@ CREATE EXTENSION IF NOT EXISTS pg_cron;
 
 -- 5b) SP-1 autorisation d'ecriture canonique (apres les RPC workspace, avant le branding)
 \i migration_permission_write_paths.sql
+-- 5c) SP-1b couverture canonique complete (tables editeur restantes)
+\i migration_permission_write_paths_b.sql
 
 -- 6) Branding UI white-label (fichier complet pour une install neuve)
 \i ui_whitelabel_branding.sql

--- a/Base de donnée DLL et API/ci_fresh_apply.sql
+++ b/Base de donnée DLL et API/ci_fresh_apply.sql
@@ -47,6 +47,8 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto;
 \ir object_workspace_gap_rpcs.sql
 \echo '== 8b     migration_permission_write_paths.sql  (SP-1 canonical-write auth; after RLS + workspace RPCs) =='
 \ir migration_permission_write_paths.sql
+\echo '== 8c     migration_permission_write_paths_b.sql  (SP-1b — complete canonical-write coverage) =='
+\ir migration_permission_write_paths_b.sql
 \echo '== 9/13  ui_whitelabel_branding.sql  (defines api.is_platform_admin) =='
 \ir ui_whitelabel_branding.sql
 \echo '== 10/13 media_bucket.sql  (storage bucket + RESTRICTIVE write RLS) =='

--- a/Base de donnée DLL et API/migration_permission_write_paths_b.sql
+++ b/Base de donnée DLL et API/migration_permission_write_paths_b.sql
@@ -1,0 +1,100 @@
+-- migration_permission_write_paths_b.sql
+-- SP-1b of P0.2 — COMPLETE the canonical-write coverage SP-1 started.
+-- SP-1 relaxed the ~24 `owner_*` write policies. This audit (CI-gate-driven) found the editor
+-- also writes ~25 more tables whose only write policy was `is_object_owner` (the `workspace_*`
+-- family), admin/service-only, or — for object_classification (§08) and object_taxonomy (§01) —
+-- NO write policy at all (RLS on ⇒ all authenticated writes denied).
+--
+-- APPROACH: purely ADDITIVE companion policies. RLS policies are OR'd, so adding a permissive
+-- `canonical_write_*` policy grants canonical writers (publisher-ORG members with
+-- edit_canonical_when_publisher, via api.user_can_write_object_canonical) without touching the
+-- existing owner/admin policies — no regression. Mirrors the owner_/workspace_ duplication already
+-- present on the covered tables.
+--
+-- PREREQUISITES: schema_unified.sql, rls_policies.sql, migration_permission_write_paths.sql
+--   (defines api.user_can_write_object_canonical). APPLY AFTER migration_permission_write_paths.sql.
+-- IDEMPOTENT: DROP POLICY IF EXISTS + CREATE. REVERSIBLE: DROP the canonical_write_* policies.
+
+BEGIN;
+
+-- ── Family A.1 — tables with a direct object_id column ──────────────────────
+DROP POLICY IF EXISTS "canonical_write_object_amenity" ON object_amenity;
+CREATE POLICY "canonical_write_object_amenity" ON object_amenity FOR ALL USING (api.user_can_write_object_canonical(object_id));
+DROP POLICY IF EXISTS "canonical_write_object_capacity" ON object_capacity;
+CREATE POLICY "canonical_write_object_capacity" ON object_capacity FOR ALL USING (api.user_can_write_object_canonical(object_id));
+DROP POLICY IF EXISTS "canonical_write_object_environment_tag" ON object_environment_tag;
+CREATE POLICY "canonical_write_object_environment_tag" ON object_environment_tag FOR ALL USING (api.user_can_write_object_canonical(object_id));
+DROP POLICY IF EXISTS "canonical_write_object_language" ON object_language;
+CREATE POLICY "canonical_write_object_language" ON object_language FOR ALL USING (api.user_can_write_object_canonical(object_id));
+DROP POLICY IF EXISTS "canonical_write_object_payment_method" ON object_payment_method;
+CREATE POLICY "canonical_write_object_payment_method" ON object_payment_method FOR ALL USING (api.user_can_write_object_canonical(object_id));
+DROP POLICY IF EXISTS "canonical_write_object_zone" ON object_zone;
+CREATE POLICY "canonical_write_object_zone" ON object_zone FOR ALL USING (api.user_can_write_object_canonical(object_id));
+DROP POLICY IF EXISTS "canonical_write_object_org_link" ON object_org_link;
+CREATE POLICY "canonical_write_object_org_link" ON object_org_link FOR ALL USING (api.user_can_write_object_canonical(object_id));
+DROP POLICY IF EXISTS "canonical_write_object_iti" ON object_iti;
+CREATE POLICY "canonical_write_object_iti" ON object_iti FOR ALL USING (api.user_can_write_object_canonical(object_id));
+DROP POLICY IF EXISTS "canonical_write_object_iti_associated_object" ON object_iti_associated_object;
+CREATE POLICY "canonical_write_object_iti_associated_object" ON object_iti_associated_object FOR ALL USING (api.user_can_write_object_canonical(object_id));
+DROP POLICY IF EXISTS "canonical_write_object_iti_info" ON object_iti_info;
+CREATE POLICY "canonical_write_object_iti_info" ON object_iti_info FOR ALL USING (api.user_can_write_object_canonical(object_id));
+DROP POLICY IF EXISTS "canonical_write_object_iti_practice" ON object_iti_practice;
+CREATE POLICY "canonical_write_object_iti_practice" ON object_iti_practice FOR ALL USING (api.user_can_write_object_canonical(object_id));
+DROP POLICY IF EXISTS "canonical_write_object_iti_profile" ON object_iti_profile;
+CREATE POLICY "canonical_write_object_iti_profile" ON object_iti_profile FOR ALL USING (api.user_can_write_object_canonical(object_id));
+DROP POLICY IF EXISTS "canonical_write_object_iti_stage" ON object_iti_stage;
+CREATE POLICY "canonical_write_object_iti_stage" ON object_iti_stage FOR ALL USING (api.user_can_write_object_canonical(object_id));
+DROP POLICY IF EXISTS "canonical_write_opening_period" ON opening_period;
+CREATE POLICY "canonical_write_opening_period" ON opening_period FOR ALL USING (api.user_can_write_object_canonical(object_id));
+DROP POLICY IF EXISTS "canonical_write_object_sustainability_action" ON object_sustainability_action;
+CREATE POLICY "canonical_write_object_sustainability_action" ON object_sustainability_action FOR ALL USING (api.user_can_write_object_canonical(object_id));
+-- §08/§01 — these had NO write policy at all (RLS on ⇒ everything denied). Add one.
+DROP POLICY IF EXISTS "canonical_write_object_classification" ON object_classification;
+CREATE POLICY "canonical_write_object_classification" ON object_classification FOR ALL USING (api.user_can_write_object_canonical(object_id));
+DROP POLICY IF EXISTS "canonical_write_object_taxonomy" ON object_taxonomy;
+CREATE POLICY "canonical_write_object_taxonomy" ON object_taxonomy FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+-- ── Family A.2 — non-object_id key columns ──────────────────────────────────
+DROP POLICY IF EXISTS "canonical_write_object_relation" ON object_relation;
+CREATE POLICY "canonical_write_object_relation" ON object_relation FOR ALL USING (api.user_can_write_object_canonical(source_object_id));
+DROP POLICY IF EXISTS "canonical_write_object_iti_section" ON object_iti_section;
+CREATE POLICY "canonical_write_object_iti_section" ON object_iti_section FOR ALL USING (api.user_can_write_object_canonical(parent_object_id));
+-- object_room_type has a direct object_id column (the existing policy joined to object only for created_by).
+DROP POLICY IF EXISTS "canonical_write_object_room_type" ON object_room_type;
+CREATE POLICY "canonical_write_object_room_type" ON object_room_type FOR ALL USING (api.user_can_write_object_canonical(object_id));
+
+-- ── Family A.3 — reach the object via a parent table (EXISTS) ───────────────
+DROP POLICY IF EXISTS "canonical_write_opening_schedule" ON opening_schedule;
+CREATE POLICY "canonical_write_opening_schedule" ON opening_schedule FOR ALL USING (
+  EXISTS (SELECT 1 FROM opening_period p WHERE p.id = opening_schedule.period_id
+          AND api.user_can_write_object_canonical(p.object_id)));
+DROP POLICY IF EXISTS "canonical_write_opening_time_frame" ON opening_time_frame;
+CREATE POLICY "canonical_write_opening_time_frame" ON opening_time_frame FOR ALL USING (
+  EXISTS (SELECT 1 FROM opening_time_period tp
+          JOIN opening_schedule s ON s.id = tp.schedule_id
+          JOIN opening_period p ON p.id = s.period_id
+          WHERE tp.id = opening_time_frame.time_period_id
+          AND api.user_can_write_object_canonical(p.object_id)));
+DROP POLICY IF EXISTS "canonical_write_object_place_description" ON object_place_description;
+CREATE POLICY "canonical_write_object_place_description" ON object_place_description FOR ALL USING (
+  EXISTS (SELECT 1 FROM object_place p WHERE p.id = object_place_description.place_id
+          AND api.user_can_write_object_canonical(p.object_id)));
+DROP POLICY IF EXISTS "canonical_write_object_room_type_amenity" ON object_room_type_amenity;
+CREATE POLICY "canonical_write_object_room_type_amenity" ON object_room_type_amenity FOR ALL USING (
+  EXISTS (SELECT 1 FROM object_room_type rt WHERE rt.id = object_room_type_amenity.room_type_id
+          AND api.user_can_write_object_canonical(rt.object_id)));
+DROP POLICY IF EXISTS "canonical_write_object_room_type_media" ON object_room_type_media;
+CREATE POLICY "canonical_write_object_room_type_media" ON object_room_type_media FOR ALL USING (
+  EXISTS (SELECT 1 FROM object_room_type rt WHERE rt.id = object_room_type_media.room_type_id
+          AND api.user_can_write_object_canonical(rt.object_id)));
+DROP POLICY IF EXISTS "canonical_write_object_sustainability_action_label" ON object_sustainability_action_label;
+CREATE POLICY "canonical_write_object_sustainability_action_label" ON object_sustainability_action_label FOR ALL USING (
+  EXISTS (SELECT 1 FROM object_sustainability_action osa WHERE osa.id = object_sustainability_action_label.object_sustainability_action_id
+          AND api.user_can_write_object_canonical(osa.object_id)));
+
+-- ── Family B — polymorphic key (tag_link: object tags only) ─────────────────
+DROP POLICY IF EXISTS "canonical_write_tag_link" ON tag_link;
+CREATE POLICY "canonical_write_tag_link" ON tag_link FOR ALL USING (
+  target_table = 'object' AND api.user_can_write_object_canonical(target_pk));
+
+COMMIT;

--- a/Base de donnée DLL et API/tests/test_sp1b_canonical_coverage.sql
+++ b/Base de donnée DLL et API/tests/test_sp1b_canonical_coverage.sql
@@ -1,0 +1,42 @@
+-- test_sp1b_canonical_coverage.sql
+-- SP-1b coverage assertion: EVERY table the object editor writes must have at least one
+-- write policy (ALL/INSERT/UPDATE) whose predicate references api.user_can_write_object_canonical.
+-- Run AFTER the full manifest (incl. migration_permission_write_paths.sql + _b.sql).
+-- This is the regression guard: if a new editor-write table is added without canonical coverage,
+-- or an existing one regresses, CI goes red. (object_description is intentionally excluded — it uses
+-- the §20 carve-out api.user_can_write_canonical + org_object_id IS NULL.)
+\set ON_ERROR_STOP on
+DO $$
+DECLARE
+  v_expected text[] := ARRAY[
+    -- SP-1b (this migration)
+    'object_amenity','object_capacity','object_environment_tag','object_language','object_payment_method',
+    'object_zone','object_org_link','object_iti','object_iti_associated_object','object_iti_info',
+    'object_iti_practice','object_iti_profile','object_iti_section','object_iti_stage','opening_period',
+    'opening_schedule','opening_time_frame','object_place_description','object_relation','tag_link',
+    'object_sustainability_action','object_sustainability_action_label','object_room_type',
+    'object_room_type_amenity','object_room_type_media','object_classification','object_taxonomy',
+    -- SP-1 (already covered)
+    'object_location','object_place','contact_channel','media','object_legal','object_discount',
+    'object_group_policy','object_price','object_price_period','object_menu','object_meeting_room',
+    'meeting_room_equipment','object_pet_policy','object_fma_occurrence','object_iti_stage_media','object_membership'
+  ];
+  v_missing text[] := ARRAY[]::text[];
+  v_t text;
+BEGIN
+  FOREACH v_t IN ARRAY v_expected LOOP
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_policies
+      WHERE schemaname='public' AND tablename = v_t AND cmd IN ('ALL','INSERT','UPDATE')
+        AND (COALESCE(qual,'')||COALESCE(with_check,'')) ILIKE '%user_can_write_object_canonical%'
+    ) THEN
+      v_missing := v_missing || v_t;
+    END IF;
+  END LOOP;
+
+  IF array_length(v_missing, 1) > 0 THEN
+    RAISE EXCEPTION 'SP-1b: editor-write tables WITHOUT a canonical-write policy: %', array_to_string(v_missing, ', ');
+  END IF;
+
+  RAISE NOTICE 'SP-1b coverage passed: % editor-write tables are canonical-covered.', array_length(v_expected, 1);
+END$$;

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ psql -d votre_database -f "Base de donnée DLL et API/object_workspace_gap_rpcs.
 
 # 5b. SP-1 autorisation d'écriture canonique (après les RPC workspace, avant le branding)
 psql -d votre_database -f "Base de donnée DLL et API/migration_permission_write_paths.sql"
+# 5c. SP-1b couverture canonique complète (tables éditeur restantes)
+psql -d votre_database -f "Base de donnée DLL et API/migration_permission_write_paths_b.sql"
 
 # 6. Branding UI white-label (fichier complet pour une installation neuve)
 psql -d votre_database -f "Base de donnée DLL et API/ui_whitelabel_branding.sql"

--- a/docs/SQL_ROLLOUT_RUNBOOK.md
+++ b/docs/SQL_ROLLOUT_RUNBOOK.md
@@ -34,6 +34,7 @@ A fresh database MUST be built in this exact order; each step depends on the pre
 7. `object_workspace_safe_write_rpcs.sql` — creates schema `internal` + the write gate `internal.workspace_assert_can_write_object`.
 8. `object_workspace_gap_rpcs.sql` — depends on step 7 and on the columns from steps 2 & 4.
 8b. `migration_permission_write_paths.sql` — **SP-1 canonical-write authorization**: additive `api.user_can_write_object_canonical` substituted into the workspace gate + 23 write policies, plus the `object.status` guard trigger. After the workspace RPCs (depends on `rls_policies.sql` helpers + the gate); before branding.
+8c. `migration_permission_write_paths_b.sql` — **SP-1b**: additive companion `canonical_write_*` policies completing canonical coverage for ~25 more editor-write tables (incl. `object_taxonomy`/`object_classification`, which had no write policy at all). After 8b.
 9. `ui_whitelabel_branding.sql` — defines `api.is_platform_admin` (a fresh install uses this full file, not the patch).
 10. `media_bucket.sql` — `media` storage bucket + RESTRICTIVE anon/authenticated write-deny.
 11. `seeds_data.sql` — depends on `ref_sustainability_action_group` from step 2.


### PR DESCRIPTION
Completes SP-1's backend coverage. A CI-audit found ~27 more editor-write tables still owner-only, admin-only, or (object_classification §08 / object_taxonomy §01) with **no write policy at all** (RLS on => all authenticated writes denied). Adds additive companion `canonical_write_*` policies via each table's object path + a structural coverage test enforcing every editor-write table stays canonical-covered. No regression (existing policies untouched). CI fresh-apply gate green (run 26865119217).

🤖 Generated with [Claude Code](https://claude.com/claude-code)