### PR TITLE
feat(iti): greenfield duration_min + elevation_loss model

### DIFF
--- a/.github/workflows/sql-fresh-apply.yml
+++ b/.github/workflows/sql-fresh-apply.yml
@@ -121,6 +121,11 @@ jobs:
           DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
         run: psql "$DB_URL" -v ON_ERROR_STOP=1 -f "Base de donnée DLL et API/tests/test_object_status_lifecycle.sql"
 
+      - name: ITI model test (duration_min + elevation_loss; get_object_resource shape; hour→minute filter)
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: psql "$DB_URL" -v ON_ERROR_STOP=1 -f "Base de donnée DLL et API/tests/test_iti_model.sql"
+
       - name: Stop Supabase
         if: always()
         run: supabase stop

--- a/Base de donnée DLL et API/Guide d’utilisation – API “Unified Objec.md
+++ b/Base de donnée DLL et API/Guide d’utilisation – API “Unified Objec.md
@@ -82,7 +82,7 @@ Chaque entrée de data[] suit ce schéma (champs présents si disponibles) :
   ],
 
   "itinerary": {
-    "distance_km": 12.5, "duration_hours": 4, "difficulty_level": 3, "elevation_gain": 450, "is_loop": false,
+    "distance_km": 12.5, "duration_min": 240, "difficulty_level": 3, "elevation_gain": 450, "elevation_loss": 380, "is_loop": false,
     "track_format": "kml",
     "track": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><kml>…</kml>"
   }

--- a/Base de donnée DLL et API/README.md
+++ b/Base de donnée DLL et API/README.md
@@ -64,6 +64,7 @@ CREATE EXTENSION IF NOT EXISTS pg_cron;
 \i migration_sustainability_v5.sql
 \i migration_room_type_ref.sql
 \i migration_tag_link_position.sql
+\i migration_iti_duration_elevation.sql
 
 -- 3) Fonctions API
 \i api_views_functions.sql

--- a/Base de donnée DLL et API/api_views_functions.sql
+++ b/Base de donnée DLL et API/api_views_functions.sql
@@ -1348,8 +1348,9 @@ AS $$
         AND ( (params.filters->'itinerary'->>'difficulty_max') IS NULL OR oi.difficulty_level <= (params.filters->'itinerary'->>'difficulty_max')::int )
         AND ( (params.filters->'itinerary'->>'distance_min_km') IS NULL OR oi.distance_km >= (params.filters->'itinerary'->>'distance_min_km')::numeric )
         AND ( (params.filters->'itinerary'->>'distance_max_km') IS NULL OR oi.distance_km <= (params.filters->'itinerary'->>'distance_max_km')::numeric )
-        AND ( (params.filters->'itinerary'->>'duration_min_h') IS NULL OR oi.duration_hours >= (params.filters->'itinerary'->>'duration_min_h')::numeric )
-        AND ( (params.filters->'itinerary'->>'duration_max_h') IS NULL OR oi.duration_hours <= (params.filters->'itinerary'->>'duration_max_h')::numeric )
+        -- Public filter contract stays in HOURS (duration_min_h / duration_max_h); object_iti.duration_min is MINUTES, so convert (h * 60).
+        AND ( (params.filters->'itinerary'->>'duration_min_h') IS NULL OR oi.duration_min >= (params.filters->'itinerary'->>'duration_min_h')::numeric * 60 )
+        AND ( (params.filters->'itinerary'->>'duration_max_h') IS NULL OR oi.duration_min <= (params.filters->'itinerary'->>'duration_max_h')::numeric * 60 )
         AND (
           params.iti_practices_any IS NULL
           OR EXISTS (
@@ -3662,9 +3663,10 @@ BEGIN
         'itinerary',
         jsonb_build_object(
           'distance_km',      i.distance_km,
-          'duration_hours',   i.duration_hours,
+          'duration_min',     i.duration_min,
           'difficulty_level', i.difficulty_level,
           'elevation_gain',   i.elevation_gain,
+          'elevation_loss',   i.elevation_loss,
           'is_loop',          i.is_loop,
           'open_status',      i.open_status,
           'status_note',      i.status_note,
@@ -7077,9 +7079,10 @@ BEGIN
       'object_id', object_id,
       'type', 'track',
       'distance_km', distance_km,
-      'duration_hours', duration_hours,
+      'duration_min', duration_min,
       'difficulty_level', difficulty_level,
       'elevation_gain', elevation_gain,
+      'elevation_loss', elevation_loss,
       'is_loop', is_loop
     )
   )

--- a/Base de donnée DLL et API/ci_fresh_apply.sql
+++ b/Base de donnée DLL et API/ci_fresh_apply.sql
@@ -37,6 +37,8 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto;
 \ir migration_room_type_ref.sql
 \echo '== 4/13  migration_tag_link_position.sql =='
 \ir migration_tag_link_position.sql
+\echo '== 4b     migration_iti_duration_elevation.sql  (object_iti duration_min + elevation_loss; before api_views) =='
+\ir migration_iti_duration_elevation.sql
 \echo '== 5/13  api_views_functions.sql =='
 \ir api_views_functions.sql
 \echo '== 6/13  rls_policies.sql  (defines api.is_object_owner) =='

--- a/Base de donnée DLL et API/erd_diagram.md
+++ b/Base de donnée DLL et API/erd_diagram.md
@@ -598,9 +598,10 @@ erDiagram
     OBJECT_ITI {
         text object_id PK,FK "Objet ITI"
         decimal distance_km "Distance (km)"
-        decimal duration_hours "Durée (h)"
+        integer duration_min "Durée (min)"
         integer difficulty_level "Difficulté (1..5)"
-        integer elevation_gain "Dénivelé (m)"
+        integer elevation_gain "Dénivelé + (m)"
+        integer elevation_loss "Dénivelé - (m)"
         boolean is_loop "Boucle"
         geography geom "Trajet principal (LINESTRING)"
     }

--- a/Base de donnée DLL et API/migration_iti_duration_elevation.sql
+++ b/Base de donnée DLL et API/migration_iti_duration_elevation.sql
@@ -1,0 +1,29 @@
+-- migration_iti_duration_elevation.sql
+-- Greenfield ITI model change (object_iti has 0 rows in prod — verified 2026-06-04):
+--   * duration_hours DECIMAL(4,2)  ->  duration_min INTEGER  (minutes)
+--   * add elevation_loss INTEGER (descent, metres) alongside the existing elevation_gain (ascent)
+--
+-- WHY: the editor already authors durations in minutes and only divided by 60 to fit the old hours
+-- column (a lossy round-trip); storing minutes removes that. The single elevation_gain column could
+-- not represent descent — elevation_loss adds it. Filtering keeps its PUBLIC contract in hours
+-- (duration_min_h / duration_max_h) and converts to minutes internally (see api_views_functions.sql).
+--
+-- Because object_iti has 0 rows, this is a destructive-but-safe retype (no data to convert): drop + add.
+-- IDEMPOTENT: DROP COLUMN IF EXISTS + ADD COLUMN IF NOT EXISTS — a no-op on a DB already at the new shape
+--   (e.g. a fresh build from schema_unified.sql, which now ships duration_min + elevation_loss directly).
+-- TRANSACTION-WRAPPED. REVERSIBLE: ALTER TABLE public.object_iti
+--   DROP COLUMN duration_min, DROP COLUMN elevation_loss, ADD COLUMN duration_hours DECIMAL(4,2);
+--
+-- PREREQUISITES: schema_unified.sql (object_iti). APPLY BEFORE api_views_functions.sql — its
+--   get_object_resource / get_filtered_object_ids / get_itinerary_track_geojson reference duration_min.
+--   Slotted at step 4b in the manifest (ci_fresh_apply.sql / docs/SQL_ROLLOUT_RUNBOOK.md).
+-- ⚠️ DEPLOY NOTE: BREAKING column change. Apply to live IN LOCKSTEP with the frontend build that reads
+--   duration_min / elevation_loss (bertel-tourism-ui/src/services/object-workspace.ts). Applying to live
+--   before the frontend ships breaks the editor's ITI read (it would still select duration_hours).
+
+BEGIN;
+ALTER TABLE public.object_iti DROP COLUMN IF EXISTS duration_hours;
+ALTER TABLE public.object_iti ADD COLUMN IF NOT EXISTS duration_min integer
+  CONSTRAINT chk_object_iti_duration_min CHECK (duration_min IS NULL OR duration_min > 0);
+ALTER TABLE public.object_iti ADD COLUMN IF NOT EXISTS elevation_loss integer;
+COMMIT;

--- a/Base de donnée DLL et API/schema_unified.sql
+++ b/Base de donnée DLL et API/schema_unified.sql
@@ -2767,9 +2767,10 @@ CREATE TABLE IF NOT EXISTS object_fma_occurrence (
 CREATE TABLE IF NOT EXISTS object_iti (
   object_id TEXT PRIMARY KEY REFERENCES object(id) ON DELETE CASCADE,
   distance_km DECIMAL(8, 2),
-  duration_hours DECIMAL(4, 2),
+  duration_min INTEGER CONSTRAINT chk_object_iti_duration_min CHECK (duration_min IS NULL OR duration_min > 0), -- minutes (greenfield retype from duration_hours; see migration_iti_duration_elevation.sql)
   difficulty_level INTEGER CHECK (difficulty_level BETWEEN 1 AND 5),
-  elevation_gain INTEGER,
+  elevation_gain INTEGER,   -- positive ascent, metres
+  elevation_loss INTEGER,   -- negative descent, metres
   is_loop BOOLEAN DEFAULT FALSE,
   geom GEOGRAPHY(LINESTRING, 4326),
   -- Cached GPX/KML for performance (auto-regenerated on geometry change)

--- a/Base de donnée DLL et API/tests/test_iti_model.sql
+++ b/Base de donnée DLL et API/tests/test_iti_model.sql
@@ -1,0 +1,67 @@
+-- test_iti_model.sql
+-- Regression test for the greenfield ITI model (object_iti has 0 rows in prod — verified 2026-06-04):
+--   * duration_hours DECIMAL  ->  duration_min INTEGER (minutes)
+--   * elevation_loss INTEGER added alongside the existing elevation_gain
+-- Asserts the schema shape, that api.get_object_resource emits `duration_min` + `elevation_loss`
+-- (and NOT `duration_hours`), and that the explorer itinerary filter keeps its PUBLIC contract in
+-- HOURS (`duration_min_h` / `duration_max_h`) while converting to minutes internally (h * 60).
+-- Run AFTER the full manifest (incl. migration_iti_duration_elevation.sql + updated api_views_functions.sql).
+-- Self-contained + transactional (ROLLBACK; nothing persists). Against the OLD model it goes red on the schema shape.
+\set ON_ERROR_STOP on
+BEGIN;
+DO $$
+DECLARE
+  v_obj text := 'ITIRUN9999999901';
+  v_iti jsonb;
+  v_ids text[];
+BEGIN
+  -- ---------- Schema shape ----------
+  ASSERT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='public' AND table_name='object_iti'
+                   AND column_name='duration_min' AND data_type='integer'),
+    'object_iti.duration_min (integer) is missing';
+  ASSERT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='public' AND table_name='object_iti'
+                   AND column_name='elevation_loss' AND data_type='integer'),
+    'object_iti.elevation_loss (integer) is missing';
+  ASSERT NOT EXISTS (SELECT 1 FROM information_schema.columns
+                     WHERE table_schema='public' AND table_name='object_iti'
+                       AND column_name='duration_hours'),
+    'object_iti.duration_hours should have been dropped (greenfield retype to duration_min)';
+
+  -- ---------- Fixture (connecting superuser; RLS bypassed) ----------
+  INSERT INTO object (id, object_type, name, status)
+    VALUES (v_obj, 'ITI', 'ITI model regression', 'published');
+  INSERT INTO object_iti (object_id, distance_km, duration_min, difficulty_level,
+                          elevation_gain, elevation_loss, is_loop)
+    VALUES (v_obj, 8.5, 120, 3, 500, 480, false);
+
+  -- ---------- get_object_resource emits duration_min + elevation_loss, never duration_hours ----------
+  v_iti := (api.get_object_resource(v_obj))::jsonb -> 'itinerary';
+  ASSERT v_iti IS NOT NULL, 'get_object_resource returned no itinerary block for an ITI object';
+  ASSERT (v_iti->>'duration_min') = '120',
+    format('itinerary.duration_min expected 120, got %s', v_iti->>'duration_min');
+  ASSERT (v_iti->>'elevation_gain') = '500', 'itinerary.elevation_gain expected 500';
+  ASSERT (v_iti->>'elevation_loss') = '480', 'itinerary.elevation_loss expected 480';
+  ASSERT NOT (v_iti ? 'duration_hours'), 'itinerary must NOT expose duration_hours';
+
+  -- ---------- Filter contract stays in HOURS, converts to minutes (120 min = 2 h) ----------
+  SELECT array_agg(object_id) INTO v_ids
+  FROM api.get_filtered_object_ids(
+    p_filters := jsonb_build_object('itinerary', jsonb_build_object('duration_max_h', 1)),
+    p_types   := ARRAY['ITI']::object_type[],
+    p_status  := ARRAY['published']::object_status[]);
+  ASSERT NOT (v_obj = ANY(COALESCE(v_ids, ARRAY[]::text[]))),
+    'duration_max_h=1 (=60 min) must EXCLUDE a 120-min itinerary';
+
+  SELECT array_agg(object_id) INTO v_ids
+  FROM api.get_filtered_object_ids(
+    p_filters := jsonb_build_object('itinerary', jsonb_build_object('duration_min_h', 1)),
+    p_types   := ARRAY['ITI']::object_type[],
+    p_status  := ARRAY['published']::object_status[]);
+  ASSERT v_obj = ANY(COALESCE(v_ids, ARRAY[]::text[])),
+    'duration_min_h=1 (=60 min) must INCLUDE a 120-min itinerary';
+
+  RAISE NOTICE 'ITI model regression assertions passed.';
+END$$;
+ROLLBACK;

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ psql -d votre_database -f "Base de donnée DLL et API/schema_unified.sql"
 psql -d votre_database -f "Base de donnée DLL et API/migration_sustainability_v5.sql"
 psql -d votre_database -f "Base de donnée DLL et API/migration_room_type_ref.sql"
 psql -d votre_database -f "Base de donnée DLL et API/migration_tag_link_position.sql"
+psql -d votre_database -f "Base de donnée DLL et API/migration_iti_duration_elevation.sql"
 
 # 3. Vues et fonctions API
 psql -d votre_database -f "Base de donnée DLL et API/api_views_functions.sql"

--- a/bertel-tourism-ui/src/features/object-drawer/ObjectDetailView.test.tsx
+++ b/bertel-tourism-ui/src/features/object-drawer/ObjectDetailView.test.tsx
@@ -642,7 +642,7 @@ describe('ObjectDetailView', () => {
         tags: [{ id: 'tag-1', name: 'Panorama' }],
         itinerary: {
           distance_km: 12.5,
-          duration_hours: 4.2,
+          duration_min: 252,
           difficulty_level: 'Intermediaire',
           elevation_gain: 540,
           is_loop: true,

--- a/bertel-tourism-ui/src/features/object-drawer/utils.test.ts
+++ b/bertel-tourism-ui/src/features/object-drawer/utils.test.ts
@@ -330,7 +330,7 @@ describe('object drawer utils', () => {
     const raw = {
       itinerary: {
         distance_km: 12.5,
-        duration_hours: 4.2,
+        duration_min: 252,
         difficulty_level: 'Intermediaire',
         elevation_gain: 540,
         is_loop: true,

--- a/bertel-tourism-ui/src/features/object-drawer/utils.ts
+++ b/bertel-tourism-ui/src/features/object-drawer/utils.ts
@@ -1315,7 +1315,13 @@ export function parseItinerarySummary(raw: Record<string, unknown>): ItinerarySu
 
   const summary: ItinerarySummary = {
     distanceKm: readString(itinerary.distance_km, readString(raw.distance_km, readString(raw.length_km, readString(raw.total_length_km)))),
-    durationHours: readString(itinerary.duration_hours, readString(raw.duration_hours, readString(raw.duration_h, readString(raw.total_duration_h)))),
+    // object_iti now stores duration in minutes (duration_min); convert to display hours.
+    // Legacy raw.duration_h / total_duration_h (already hours) remain a fallback.
+    durationHours: ((): string => {
+      const minutes = Number(itinerary.duration_min ?? raw.duration_min);
+      if (Number.isFinite(minutes) && minutes > 0) return String(Math.round((minutes / 60) * 100) / 100);
+      return readString(raw.duration_h, readString(raw.total_duration_h));
+    })(),
     difficulty: readNamedValue(itinerary.difficulty, readString(itinerary.difficulty_level, readNamedValue(raw.difficulty, readString(raw.difficulty_level)))),
     elevationGain: readString(itinerary.elevation_gain, readString(raw.elevation_gain, readString(raw.elevation_gain_m))),
     isLoop: loopValue,

--- a/bertel-tourism-ui/src/services/object-workspace-parser.ts
+++ b/bertel-tourism-ui/src/services/object-workspace-parser.ts
@@ -1864,7 +1864,7 @@ function parseWorkspaceEventModule(raw: Record<string, unknown>): ObjectWorkspac
   };
 }
 
-function parseWorkspaceItineraryModule(raw: Record<string, unknown>): ObjectWorkspaceItineraryModule {
+export function parseWorkspaceItineraryModule(raw: Record<string, unknown>): ObjectWorkspaceItineraryModule {
   const itinerary = readRecord(raw.itinerary ?? raw.object_iti);
   const details = readRecord(raw.itinerary_details);
   const practiceRecords = [
@@ -1889,7 +1889,7 @@ function parseWorkspaceItineraryModule(raw: Record<string, unknown>): ObjectWork
     durationMin: readString(itinerary.duration_min, readString(raw.duration_min, readString(raw.total_duration_min))),
     difficultyLevel: readString(itinerary.difficulty_level, readString(raw.difficulty_level)),
     elevationPositiveM: readString(itinerary.elevation_positive_m, readString(itinerary.elevation_gain, readString(raw.elevation_gain_m))),
-    elevationNegativeM: readString(itinerary.elevation_negative_m, readString(raw.elevation_negative_m)),
+    elevationNegativeM: readString(itinerary.elevation_loss, readString(itinerary.elevation_negative_m, readString(raw.elevation_negative_m))),
     loop: readBoolean(itinerary.is_loop ?? raw.is_loop),
     openStatus: readString(itinerary.open_status, 'open'),
     statusNote: readString(itinerary.status_note),

--- a/bertel-tourism-ui/src/services/object-workspace.itinerary-parse.test.ts
+++ b/bertel-tourism-ui/src/services/object-workspace.itinerary-parse.test.ts
@@ -1,0 +1,22 @@
+import { parseWorkspaceItineraryModule } from './object-workspace-parser';
+
+// Pins the itinerary READ contract to the api.get_object_resource payload after the greenfield retype:
+// the resource emits duration_min + elevation_gain + elevation_loss (never duration_hours / *_positive_m).
+describe('parseWorkspaceItineraryModule', () => {
+  it('reads duration_min, elevation_gain and elevation_loss from the itinerary payload', () => {
+    const m = parseWorkspaceItineraryModule({
+      itinerary: {
+        distance_km: 8.5,
+        duration_min: 120,
+        difficulty_level: 3,
+        elevation_gain: 500,
+        elevation_loss: 480,
+        is_loop: false,
+        open_status: 'open',
+      },
+    });
+    expect(m.durationMin).toBe('120');
+    expect(m.elevationPositiveM).toBe('500');
+    expect(m.elevationNegativeM).toBe('480'); // from elevation_loss
+  });
+});

--- a/bertel-tourism-ui/src/services/object-workspace.itinerary.test.ts
+++ b/bertel-tourism-ui/src/services/object-workspace.itinerary.test.ts
@@ -1,0 +1,60 @@
+import { buildItineraryUpsertPayload } from './object-workspace';
+import type { ObjectWorkspaceItineraryModule } from './object-workspace-parser';
+
+// Pins the object_iti WRITE contract to the REAL columns after the greenfield retype
+// (duration_hours -> duration_min INTEGER; elevation_gain + elevation_loss).
+// The previous save wrote elevation_positive_m / elevation_negative_m, which do NOT exist
+// in the object_iti DDL — so every itinerary save silently failed. This test guards against
+// regressing to non-existent columns.
+const baseInput: ObjectWorkspaceItineraryModule = {
+  distanceKm: '8.5',
+  durationMin: '120',
+  difficultyLevel: '3',
+  elevationPositiveM: '500',
+  elevationNegativeM: '480',
+  loop: false,
+  openStatus: 'open',
+  statusNote: '',
+  practiceOptions: [],
+  practiceCodes: [],
+  stages: [],
+  sectionsCount: 0,
+  profilesCount: 0,
+  geometrySummary: '',
+  traceEditable: false,
+  unavailableReason: null,
+};
+
+describe('buildItineraryUpsertPayload', () => {
+  it('maps editor fields to the real object_iti columns', () => {
+    const p = buildItineraryUpsertPayload('ITI1', baseInput);
+    expect(p).toMatchObject({
+      object_id: 'ITI1',
+      distance_km: 8.5,
+      duration_min: 120,        // minutes, stored directly (no hours round-trip)
+      elevation_gain: 500,      // was elevation_positive_m (non-existent)
+      elevation_loss: 480,      // was elevation_negative_m (non-existent)
+      is_loop: false,
+      open_status: 'open',
+    });
+  });
+
+  it('never writes columns absent from the object_iti DDL', () => {
+    const p = buildItineraryUpsertPayload('ITI1', baseInput) as Record<string, unknown>;
+    expect('elevation_positive_m' in p).toBe(false);
+    expect('elevation_negative_m' in p).toBe(false);
+    expect('duration_hours' in p).toBe(false);
+  });
+
+  it('coerces empty numeric strings to null', () => {
+    const p = buildItineraryUpsertPayload('ITI1', {
+      ...baseInput,
+      durationMin: '',
+      elevationPositiveM: '',
+      elevationNegativeM: '',
+    });
+    expect(p.duration_min).toBeNull();
+    expect(p.elevation_gain).toBeNull();
+    expect(p.elevation_loss).toBeNull();
+  });
+});

--- a/bertel-tourism-ui/src/services/object-workspace.ts
+++ b/bertel-tourism-ui/src/services/object-workspace.ts
@@ -2679,7 +2679,7 @@ async function getObjectWorkspaceItineraryModule(
   const [itiResult, practiceRefsResult, practicesResult, stagesResult] = await Promise.allSettled([
     client
       .from('object_iti')
-      .select('distance_km, duration_hours, difficulty_level, elevation_gain, is_loop, open_status, status_note, geom')
+      .select('distance_km, duration_min, difficulty_level, elevation_gain, elevation_loss, is_loop, open_status, status_note, geom')
       .eq('object_id', objectId)
       .maybeSingle(),
     client.from('ref_code').select('id, code, name, position').eq('domain', 'iti_practice').order('position', { ascending: true }),
@@ -2713,22 +2713,15 @@ async function getObjectWorkspaceItineraryModule(
       }))
     : baseModule.stages;
 
-  // object_iti stores duration in hours; the editor's durationMin field is minutes
-  // (BlockITI divides by 60 to display hours). The table has a single elevation_gain
-  // column and no negative-elevation column — elevationNegativeM keeps whatever the
-  // detail payload supplied via baseModule.
-  const durationHours = Number(row.duration_hours);
-  const durationMinValue = row.duration_hours != null && Number.isFinite(durationHours)
-    ? String(Math.round(durationHours * 60))
-    : baseModule.durationMin;
-
+  // object_iti.duration_min is stored in minutes (greenfield retype from duration_hours); read it
+  // directly — no hours->minutes round-trip. elevation_loss carries descent (was unavailable before).
   return {
     ...baseModule,
     distanceKm: readString(row.distance_km, baseModule.distanceKm),
-    durationMin: durationMinValue,
+    durationMin: readString(row.duration_min, baseModule.durationMin),
     difficultyLevel: readString(row.difficulty_level, baseModule.difficultyLevel),
     elevationPositiveM: readString(row.elevation_gain, baseModule.elevationPositiveM),
-    elevationNegativeM: baseModule.elevationNegativeM,
+    elevationNegativeM: readString(row.elevation_loss, baseModule.elevationNegativeM),
     loop: row.is_loop == null ? baseModule.loop : readBoolean(row.is_loop),
     openStatus: readString(row.open_status, baseModule.openStatus || 'open'),
     statusNote: readString(row.status_note, baseModule.statusNote),
@@ -4296,6 +4289,28 @@ export async function saveObjectWorkspaceEvent(objectId: string, input: ObjectWo
   }
 }
 
+/**
+ * Pure builder for the object_iti upsert row. Maps editor fields to the REAL columns after the
+ * greenfield retype (migration_iti_duration_elevation.sql): durationMin -> duration_min (minutes),
+ * elevationPositiveM -> elevation_gain, elevationNegativeM -> elevation_loss. The previous inline
+ * payload wrote elevation_positive_m / elevation_negative_m, which do NOT exist in object_iti — so
+ * every itinerary save silently failed. geom / cached_gpx are intentionally NOT written here: trace
+ * geometry stays read-only until a write/validation contract exists.
+ */
+export function buildItineraryUpsertPayload(objectId: string, input: ObjectWorkspaceItineraryModule) {
+  return {
+    object_id: objectId,
+    distance_km: toNullableNumber(input.distanceKm),
+    duration_min: toNullableInteger(input.durationMin),
+    difficulty_level: toNullableText(input.difficultyLevel),
+    elevation_gain: toNullableInteger(input.elevationPositiveM),
+    elevation_loss: toNullableInteger(input.elevationNegativeM),
+    is_loop: input.loop,
+    open_status: toNullableText(input.openStatus) ?? 'open',
+    status_note: toNullableText(input.statusNote),
+  };
+}
+
 export async function saveObjectWorkspaceItinerary(objectId: string, input: ObjectWorkspaceItineraryModule): Promise<void> {
   const session = useSessionStore.getState();
   if (session.demoMode) {
@@ -4314,17 +4329,8 @@ export async function saveObjectWorkspaceItinerary(objectId: string, input: Obje
   const practiceIdByCode = buildCodeIdMap(practiceRefsResult.data ?? []);
   ensureKnownCodes(input.practiceCodes, practiceIdByCode, 'Pratique itineraire');
 
-  const { error } = await client.from('object_iti').upsert({
-    object_id: objectId,
-    distance_km: toNullableNumber(input.distanceKm),
-    duration_min: toNullableInteger(input.durationMin),
-    difficulty_level: toNullableText(input.difficultyLevel),
-    elevation_positive_m: toNullableInteger(input.elevationPositiveM),
-    elevation_negative_m: toNullableInteger(input.elevationNegativeM),
-    is_loop: input.loop,
-    open_status: toNullableText(input.openStatus) ?? 'open',
-    status_note: toNullableText(input.statusNote),
-  }, { onConflict: 'object_id' });
+  const { error } = await client.from('object_iti')
+    .upsert(buildItineraryUpsertPayload(objectId, input), { onConflict: 'object_id' });
 
   if (error) {
     throw mapMutationError(error, 'Impossible de sauvegarder l itineraire.');

--- a/docs/SQL_ROLLOUT_RUNBOOK.md
+++ b/docs/SQL_ROLLOUT_RUNBOOK.md
@@ -29,6 +29,7 @@ A fresh database MUST be built in this exact order; each step depends on the pre
 2. `migration_sustainability_v5.sql` — DDL; **prerequisite for the V5 sections of `seeds_data.sql`** (creates `ref_sustainability_action_group` + equivalence tables/views).
 3. `migration_room_type_ref.sql` — DDL; adds `object_room_type.room_type_id`.
 4. `migration_tag_link_position.sql` — DDL; adds `tag_link.position` (required at runtime by `api.save_object_workspace_tags`).
+4b. `migration_iti_duration_elevation.sql` — DDL; greenfield ITI retype `object_iti.duration_hours` → `duration_min INTEGER` + adds `elevation_loss INTEGER`. **Before** `api_views_functions.sql` (its `get_object_resource` / `get_filtered_object_ids` / `get_itinerary_track_geojson` reference `duration_min`). Idempotent (`schema_unified.sql` already ships the new shape, so this is a no-op on a fresh DB). ⚠️ BREAKING for live — apply in lockstep with the frontend build that reads `duration_min`/`elevation_loss`.
 5. `api_views_functions.sql`
 6. `rls_policies.sql` — defines `api.is_object_owner` (needed by step 7).
 7. `object_workspace_safe_write_rpcs.sql` — creates schema `internal` + the write gate `internal.workspace_assert_can_write_object`.

--- a/docs/architecture/OBJECT_DATA_DICTIONARY.md
+++ b/docs/architecture/OBJECT_DATA_DICTIONARY.md
@@ -810,9 +810,10 @@ These panels only appear when the `object_type` matches.
 | Field | Type | Required | Purpose |
 |-------|------|----------|---------|
 | `distance_km` | `DECIMAL(8,2)` | No | Total distance in kilometers. |
-| `duration_hours` | `DECIMAL(4,2)` | No | Estimated completion time in hours. |
+| `duration_min` | `INTEGER` | No | Estimated completion time in **minutes** (greenfield retype from `duration_hours`; `CHECK > 0`). |
 | `difficulty_level` | `INTEGER (1–5)` | No | 1 = easy, 5 = expert. |
-| `elevation_gain` | `INTEGER` | No | Total positive elevation gain in meters. |
+| `elevation_gain` | `INTEGER` | No | Total positive elevation (ascent) in metres. |
+| `elevation_loss` | `INTEGER` | No | Total negative elevation (descent) in metres. |
 | `is_loop` | `BOOLEAN` | No | Whether the trail returns to its starting point. |
 | `geom` | `GEOGRAPHY(LINESTRING)` | No | Full trace geometry. Powers the map display and GPX export. |
 | `cached_gpx` / `cached_kml` | `TEXT` | No | Pre-generated export formats. Auto-regenerated on geometry change. |
@@ -820,7 +821,7 @@ These panels only appear when the `object_type` matches.
 | `status_note` | `TEXT` | No | Human-readable note explaining the status (e.g., storm damage on section 3). |
 | `status_document_id` | `UUID` (FK) | No | Official document backing the status change. |
 
-> ⚠️ **Editor write reality (audited 2026-06-04 — front/DB drift, not yet fixed):** the ITI summary save in `bertel-tourism-ui/src/services/object-workspace.ts` (`saveObjectWorkspaceItinerary`, ~L4317) does a direct `.from('object_iti').upsert(...)` writing **`duration_min`, `elevation_positive_m`, `elevation_negative_m` — columns that do not exist** on `object_iti` (the table has `duration_hours` + `elevation_gain`). Those three fields therefore fail to persist. The read/parser path also reads `duration_min` (vs DB `duration_hours`). `geom` is read-only in the editor (no write/validation contract). A nested write RPC `api.save_object_itinerary_nested(p_object_id text, p_payload jsonb)` **exists** but the summary path does not use it. **Default resolution (no DDL change): adapt the front to write `duration_hours`/`elevation_gain`, or route through the RPC** — adding columns is gated on an explicit product decision. Tracked with the §15 Relations/ITI write-traps in `lot1_mapping_decisions.md` §24 / P1.2. The full ITI sub-object matrix (stages, stage media, sections, profile, associated objects, incoming/outgoing relations) + the `itinerary` / `itinerary_details` / `outgoing_relations` / `incoming_relations` payload contract is a **deferred** dictionary pass.
+> **Editor write model (2026-06-04, §28):** the **summary** fields above are saved by the editor via a **direct `object_iti` upsert** (`bertel-tourism-ui/src/services/object-workspace.ts` → `buildItineraryUpsertPayload`): `duration_min` (minutes), `elevation_gain` (ascent), `elevation_loss` (descent). **`geom` / `cached_gpx` stay read-only** — no editor write contract yet. `api.save_object_itinerary_nested(text, jsonb)` exists for nested rows (info, stages, sections, profile, associated objects) but **stages are not wired in the save dispatcher yet** (Phase 1 deferred — RPC delete-all-then-reinsert; see `lot1_mapping_decisions.md` §28). The explorer itinerary filter keeps its public contract in **hours** (`duration_min_h` / `duration_max_h`) and converts to minutes internally (`× 60`) in `api.get_filtered_object_ids`.
 
 Additional ITI sub-tables:
 - `object_iti_practice` (M:N): Sports practices applicable to this trail (hiking, mountain bike, horse riding, etc.)

--- a/docs/doc_api_bertel_v3.html
+++ b/docs/doc_api_bertel_v3.html
@@ -1406,9 +1406,10 @@ const json = await res.json();</pre>
               <thead><tr><th>Champ</th><th>Type</th><th>Description</th></tr></thead>
               <tbody>
                 <tr><td><code>distance_km</code></td><td><code>number</code></td><td>Distance totale (km)</td></tr>
-                <tr><td><code>duration_hours</code></td><td><code>number</code></td><td>Durée moyenne (h)</td></tr>
+                <tr><td><code>duration_min</code></td><td><code>number</code></td><td>Durée (min)</td></tr>
                 <tr><td><code>difficulty_level</code></td><td><code>number</code></td><td>Niveau (échelle interne)</td></tr>
                 <tr><td><code>elevation_gain</code></td><td><code>number</code></td><td>Dénivelé + (m)</td></tr>
+                <tr><td><code>elevation_loss</code></td><td><code>number</code></td><td>Dénivelé - (m)</td></tr>
                 <tr><td><code>is_loop</code></td><td><code>boolean</code></td><td>Boucle ?</td></tr>
                 <tr><td><code>track</code></td><td><code>string | null</code></td><td>KML/GPX (XML texte) — uniquement si demandé</td></tr>
                 <tr><td><code>track_format</code></td><td><code>"kml" | "gpx" | null</code></td><td>Format du tracé si présent</td></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3820,9 +3820,10 @@ const json = await res.json();</pre>
               <thead><tr><th>Champ</th><th>Type</th><th>Description</th></tr></thead>
               <tbody>
                 <tr><td><code>distance_km</code></td><td><code>number</code></td><td>Distance totale (km)</td></tr>
-                <tr><td><code>duration_hours</code></td><td><code>number</code></td><td>Durée moyenne (h)</td></tr>
+                <tr><td><code>duration_min</code></td><td><code>number</code></td><td>Durée (min)</td></tr>
                 <tr><td><code>difficulty_level</code></td><td><code>number</code></td><td>Niveau (échelle interne)</td></tr>
                 <tr><td><code>elevation_gain</code></td><td><code>number</code></td><td>Dénivelé + (m)</td></tr>
+                <tr><td><code>elevation_loss</code></td><td><code>number</code></td><td>Dénivelé - (m)</td></tr>
                 <tr><td><code>is_loop</code></td><td><code>boolean</code></td><td>Boucle ?</td></tr>
                 <tr><td><code>track</code></td><td><code>string | null</code></td><td>KML/GPX (XML texte) — uniquement si demandé</td></tr>
                 <tr><td><code>track_format</code></td><td><code>"kml" | "gpx" | null</code></td><td>Format du tracé si présent</td></tr>

--- a/docs/mapping-workbench/dbml/bertel-core-object-surface.dbml
+++ b/docs/mapping-workbench/dbml/bertel-core-object-surface.dbml
@@ -449,9 +449,10 @@ Table object_legal {
 Table object_iti {
   object_id text [pk]
   distance_km decimal
-  duration_hours decimal
+  duration_min integer
   difficulty_level integer
   elevation_gain integer
+  elevation_loss integer
   is_loop boolean
   geom geography
   open_status text

--- a/docs/schema-workbench/contracts/itinerary-write-contract.md
+++ b/docs/schema-workbench/contracts/itinerary-write-contract.md
@@ -8,15 +8,15 @@ The itinerary module is partially writable today. Basic `object_iti` fields and 
 
 `api.save_object_itinerary_nested(p_object_id text, p_payload jsonb)` is defined in `Base de donnée DLL et API/object_workspace_safe_write_rpcs.sql`.
 
-The RPC covers `object_iti_info`, stages, stage media, sections, profiles, and associated objects. Geometry keys are accepted only as skipped fields and return warnings until a geometry validation contract exists. Basic `object_iti` fields stay on the existing save path until the live schema mismatch around duration/elevation column names is resolved.
+The RPC covers `object_iti_info`, stages, stage media, sections, profiles, and associated objects. Geometry keys are accepted only as skipped fields and return warnings until a geometry validation contract exists. Basic `object_iti` summary fields (distance, `duration_min`, difficulty, `elevation_gain`, `elevation_loss`, loop, open status, status note) stay on the direct `object_iti` upsert save path (`buildItineraryUpsertPayload`); the earlier duration/elevation column-name mismatch is **resolved** — greenfield retype to `duration_min` (minutes) + added `elevation_loss`.
 
 ## Editable Fields
 
 Already safe:
 - distance.
-- duration, with a frontend/schema mapping gap to resolve between `duration_min` and DB `duration_hours`.
+- duration — **resolved**: the DB column is now `duration_min` (minutes), matching the editor field; no conversion on read/write.
 - difficulty.
-- elevation gain, with a frontend/schema mapping gap to resolve for negative elevation.
+- elevation gain (`elevation_gain`) and negative elevation (`elevation_loss`) — **resolved**: both columns exist; the editor maps elevationPositiveM → `elevation_gain` and elevationNegativeM → `elevation_loss`.
 - loop flag.
 - open status.
 - status note.


### PR DESCRIPTION
## Summary

Greenfield ITI model retype with **zero rows in prod**: `object_iti.duration_hours` → `duration_min` (minutes, `CHECK > 0`) and new `elevation_loss` alongside `elevation_gain`.

- **SQL:** `migration_iti_duration_elevation.sql`, `schema_unified.sql`, `get_object_resource` / `get_itinerary_track_geojson` emit `duration_min` + `elevation_loss`; explorer filter keeps **hours** (`duration_min_h` / `duration_max_h`) with `× 60` internally.
- **Frontend:** save/read/parser + drawer aligned; summary write-trap closed (`elevationPositiveM` → `elevation_gain`, `elevationNegativeM` → `elevation_loss`).
- **Docs:** dictionary §E1, ERD/DBML, API guide, write-contract, `index.html` + `doc_api_bertel_v3.html`.
- **Tests:** `test_iti_model.sql` (RED-first); vitest save/parser/drawer specs; full FE suite green (338 tests).

**Stages:** BlockITI edits stages in the draft, but save does **not** call `save_object_itinerary_nested` yet (destructive delete-all-then-reinsert — deferred §28 / follow-up PR).

## Breaking deploy

Apply `migration_iti_duration_elevation.sql` **in lockstep** with the frontend deploy. Migration is **not** applied to live yet; dropping `duration_hours` breaks the current editor read until this build ships.

## Commits

1. `200860a` — SQL + deploy gate (migration, API fns, CI manifest 4b, runbook, READMEs)
2. `f68d84d` — Frontend save/read/parser + drawer + tests
3. `6e3c60c` — Docs sweep

## Test plan

- [ ] CI `sql-fresh-apply` includes step 4b + `test_iti_model.sql`
- [ ] `npm test` in `bertel-tourism-ui` (338 tests)
- [ ] After merge: apply migration + deploy UI together on live
- [ ] Smoke: edit ITI duration (min) + D+/D−, save draft/publish, reload

## Note

May conflict with `fix/object-act-rls-security` on manifest/README/dictionary — rebase whichever merges second.
