### PR TITLE
feat(iti): wire save_object_itinerary_nested for stages (Phase 1)

### DIFF
--- a/bertel-tourism-ui/src/services/object-workspace.itinerary.test.ts
+++ b/bertel-tourism-ui/src/services/object-workspace.itinerary.test.ts
@@ -1,4 +1,4 @@
-import { buildItineraryUpsertPayload } from './object-workspace';
+import { buildItineraryUpsertPayload, buildItineraryStagesPayload } from './object-workspace';
 import type { ObjectWorkspaceItineraryModule } from './object-workspace-parser';
 
 // Pins the object_iti WRITE contract to the REAL columns after the greenfield retype
@@ -56,5 +56,32 @@ describe('buildItineraryUpsertPayload', () => {
     expect(p.duration_min).toBeNull();
     expect(p.elevation_gain).toBeNull();
     expect(p.elevation_loss).toBeNull();
+  });
+});
+
+describe('buildItineraryStagesPayload', () => {
+  // Phase 1: stages persist via api.save_object_itinerary_nested, which replaces all stages
+  // (delete + reinsert). The editor manages stages (BlockITI / SectionPlaces add/edit/remove),
+  // so module.stages is the source of truth; the guard below avoids clobbering on a failed load.
+  const stages = [
+    { recordId: 'stage-1', name: 'Col de Bellevue', description: 'Point haut', position: '1' },
+    { recordId: null, name: 'Nouvelle etape', description: '', position: '2' },
+  ];
+
+  it('maps managed stages to the RPC shape — recordId becomes id, new rows omit id', () => {
+    expect(buildItineraryStagesPayload({ ...baseInput, stages })).toEqual([
+      { id: 'stage-1', name: 'Col de Bellevue', description: 'Point haut', position: '1' },
+      { name: 'Nouvelle etape', description: '', position: '2' },
+    ]);
+  });
+
+  it('returns null when the module did not load (guard against clobbering existing stages)', () => {
+    expect(
+      buildItineraryStagesPayload({ ...baseInput, stages, unavailableReason: 'Le live ne fournit pas le detail.' }),
+    ).toBeNull();
+  });
+
+  it('returns [] for a loaded module with no stages (intentional clear)', () => {
+    expect(buildItineraryStagesPayload(baseInput)).toEqual([]);
   });
 });

--- a/bertel-tourism-ui/src/services/object-workspace.ts
+++ b/bertel-tourism-ui/src/services/object-workspace.ts
@@ -4311,6 +4311,28 @@ export function buildItineraryUpsertPayload(objectId: string, input: ObjectWorks
   };
 }
 
+/**
+ * Pure builder for the `stages` payload of api.save_object_itinerary_nested (Phase 1). Maps the
+ * editor's managed stage rows (BlockITI / SectionPlaces add/edit/remove) to the RPC shape:
+ * recordId -> id (existing stage, preserved); new rows omit id so the RPC generates one.
+ * Returns null when the itinerary module did NOT load (unavailableReason set) — the RPC replaces
+ * all stages (delete + reinsert), so a partial/failed load must not clobber the object's existing
+ * stages. An empty array is intentional (user removed every stage) and correctly clears them.
+ */
+export function buildItineraryStagesPayload(
+  input: ObjectWorkspaceItineraryModule,
+): Array<{ id?: string; name: string; description: string; position: string }> | null {
+  if (input.unavailableReason != null) {
+    return null;
+  }
+  return input.stages.map((stage) => ({
+    ...(stage.recordId ? { id: stage.recordId } : {}),
+    name: stage.name,
+    description: stage.description,
+    position: stage.position,
+  }));
+}
+
 export async function saveObjectWorkspaceItinerary(objectId: string, input: ObjectWorkspaceItineraryModule): Promise<void> {
   const session = useSessionStore.getState();
   if (session.demoMode) {
@@ -4350,6 +4372,20 @@ export async function saveObjectWorkspaceItinerary(objectId: string, input: Obje
     if (practicesError) {
       throw mapMutationError(practicesError, 'Impossible de sauvegarder les pratiques itineraire.');
     }
+  }
+
+  // Phase 1: persist itinerary stages (object_iti_stage) via api.save_object_itinerary_nested, which
+  // replaces all stages (delete + reinsert). buildItineraryStagesPayload returns null when the module
+  // did not load, so a partial/failed load cannot clobber existing stages. Only `stages` is sent —
+  // sections / profiles / associated objects / geom are out of scope (Phase 1; geom stays read-only).
+  const stagesPayload = buildItineraryStagesPayload(input);
+  if (stagesPayload !== null) {
+    await callObjectWorkspaceRpc(
+      'save_object_itinerary_nested',
+      objectId,
+      { stages: stagesPayload },
+      'Impossible de sauvegarder les etapes itineraire.',
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Persist `object_iti_stage` from the editor — BlockITI (§05) and SectionPlaces (§16) already manage editable stage rows bound to `module.itinerary.stages`.

- **`buildItineraryStagesPayload`** (new exported pure fn): maps managed stages → RPC shape (`recordId` → `id`; new rows omit `id`).
- **Guard:** returns `null` when `unavailableReason` is set — failed/partial load cannot clobber existing stages via the RPC's delete-all-reinsert. An empty array intentionally clears stages.
- **`saveObjectWorkspaceItinerary`:** after summary upsert + practices, calls `save_object_itinerary_nested` with `{ stages }` when payload is non-null.

**Out of scope:** sections, profiles, associated objects, geom (read-only).

## Verification

- TDD: 3 new specs RED → GREEN
- Full FE suite: **341 tests** pass (+3); `tsc` clean
- **Frontend-only** — no SQL/manifest change (RPC already on live + in manifest). SQL fresh-apply gate **will not run** on this PR; no frontend CI workflow — local Jest + tsc are the verification.

## Deploy

No new SQL dependency. Rides the same frontend build as #31 (`duration_min` / `elevation_loss`). Prod cutover still requires applying `migration_iti_duration_elevation.sql` **in lockstep** with the UI deploy (summary columns); stages use `object_iti_stage`, unaffected by that migration.

## Test plan

- [ ] Local: `npm test` + `tsc` in `bertel-tourism-ui`
- [ ] After deploy: edit stages in BlockITI → save draft → reload → stages persist
- [ ] Guard: simulate unavailable module → save must not wipe stages
