### PR TITLE
fix(explorer): preserve map container height through route motion

### DIFF
--- a/bertel-tourism-ui/src/components/layout/RouteMotion.test.tsx
+++ b/bertel-tourism-ui/src/components/layout/RouteMotion.test.tsx
@@ -14,6 +14,17 @@ describe('RouteMotion', () => {
     expect(screen.getByText('Explorer content').closest('.motion-page-enter')).toBeInTheDocument();
   });
 
+  it('preserves the full-height flex chain required by routed workspaces', () => {
+    render(
+      <RouteMotion>
+        <div>Full-height content</div>
+      </RouteMotion>,
+    );
+
+    const wrapper = screen.getByText('Full-height content').closest('.motion-page-enter');
+    expect(wrapper).toHaveClass('flex', 'h-full', 'min-h-0', 'w-full', 'min-w-0', 'flex-col');
+  });
+
   it('renders new content when the pathname changes (remount, not a stale wrapper)', () => {
     const { rerender } = render(
       <RouteMotion>

--- a/bertel-tourism-ui/src/components/layout/RouteMotion.tsx
+++ b/bertel-tourism-ui/src/components/layout/RouteMotion.tsx
@@ -13,7 +13,10 @@ import { usePathname } from 'next/navigation';
 export function RouteMotion({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   return (
-    <div key={pathname} className="motion-page-enter">
+    <div
+      key={pathname}
+      className="motion-page-enter flex h-full min-h-0 w-full min-w-0 flex-col"
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
## What changed

- Make the `RouteMotion` wrapper a full-height, min-height-safe flex column.
- Add a regression test that pins the routed workspace sizing contract.

## Why

The route-transition wrapper introduced in the previous UI push inserted an auto-height `<div>` between the application shell and `ExplorerPage`. That broke the definite-height chain used by the Explorer layout, allowing the MapLibre canvas to collapse to zero height.

## Impact

The Explorer map keeps the available workspace height again in map and split views.

## Validation

- `RouteMotion.test.tsx`: 3/3 tests passed.
- `git diff --check`: passed.
- The full Next.js production build was attempted twice but remained stuck in `Creating an optimized production build` until the environment timeout; it did not report a TypeScript or bundling error.