### PR TITLE
CRM : déplacer les documents d’accompagnement dans un onglet

### DIFF
--- a/bertel-tourism-ui/src/features/crm/CrmActorDocuments.tsx
+++ b/bertel-tourism-ui/src/features/crm/CrmActorDocuments.tsx
@@ -41,6 +41,104 @@ function formatBytes(value: number): string {
   return `${(value / (1024 * 1024)).toFixed(1).replace('.', ',')} Mo`;
 }
 
+function useActorDocumentAccessToken() {
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    const client = getSupabaseClient();
+    if (!client) return;
+    void client.auth.getSession().then(({ data }) => {
+      if (alive) setAccessToken(data.session?.access_token ?? null);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return accessToken;
+}
+
+/** Zone d'ajout dédiée au rail droit de l'onglet Documents. */
+export function CrmActorDocumentDropzone({
+  actorId,
+  canWrite,
+}: {
+  actorId: string;
+  canWrite: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const accessToken = useActorDocumentAccessToken();
+  const [isDragging, setIsDragging] = useState(false);
+
+  const refresh = () => queryClient.invalidateQueries({ queryKey: ['crm-actor-support', actorId] });
+  const uploadMutation = useMutation({
+    mutationFn: async (file: File) => {
+      if (!accessToken) throw new Error('Session expirée. Reconnectez-vous pour ajouter un document.');
+      return uploadActorDocument({ actorId, file, accessToken });
+    },
+    onSuccess: () => {
+      if (fileInputRef.current) fileInputRef.current.value = '';
+      void refresh();
+    },
+  });
+
+  const canUpload = canWrite && Boolean(accessToken) && !uploadMutation.isPending;
+  const disabledReason = !canWrite
+    ? CRM_READ_ONLY_REASON
+    : !accessToken
+      ? 'Session indisponible. Reconnectez-vous pour ajouter un document.'
+      : undefined;
+
+  function addFile(file: File | undefined) {
+    if (file && canUpload) uploadMutation.mutate(file);
+  }
+
+  return (
+    <section className="rcard crm-actor-docs-upload" aria-labelledby="crm-actor-documents-upload-title">
+      <h4 id="crm-actor-documents-upload-title">Ajouter un document</h4>
+      <button
+        type="button"
+        className={'crm-actor-docs-dropzone' + (isDragging ? ' is-dragging' : '')}
+        disabled={!canUpload}
+        title={disabledReason}
+        onClick={() => fileInputRef.current?.click()}
+        onDragEnter={(event) => {
+          event.preventDefault();
+          if (canUpload) setIsDragging(true);
+        }}
+        onDragOver={(event) => event.preventDefault()}
+        onDragLeave={(event) => {
+          event.preventDefault();
+          setIsDragging(false);
+        }}
+        onDrop={(event) => {
+          event.preventDefault();
+          setIsDragging(false);
+          addFile(event.dataTransfer.files?.[0]);
+        }}
+      >
+        <Upload size={22} aria-hidden />
+        <strong>{uploadMutation.isPending ? 'Ajout en cours…' : 'Déposez un fichier ici'}</strong>
+        <span>ou cliquez pour le sélectionner</span>
+        <small>JPG, PNG, WebP · 2 000 px max<br />PDF · 5 Mo max</small>
+      </button>
+      <input
+        ref={fileInputRef}
+        className="crm-actor-docs__file-input"
+        type="file"
+        accept="application/pdf,image/jpeg,image/png,image/webp"
+        aria-label="Sélectionner un document à ajouter"
+        onChange={(event) => addFile(event.target.files?.[0])}
+      />
+      {uploadMutation.isError && (
+        <div className="inline-alert" role="alert">{errorMessage(uploadMutation.error)}</div>
+      )}
+    </section>
+  );
+}
+
 /**
  * Bibliothèque privée d'un acteur en accompagnement. Un fichier reste indépendant de tout
  * établissement jusqu'à son transfert explicite vers object_document.
@@ -55,8 +153,7 @@ export function CrmActorDocuments({
   objects: LinkedObjectOption[];
 }) {
   const queryClient = useQueryClient();
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const accessToken = useActorDocumentAccessToken();
   const [promotion, setPromotion] = useState<PromotionDraft | null>(null);
   const [openingDocumentId, setOpeningDocumentId] = useState<string | null>(null);
   const [openError, setOpenError] = useState<string | null>(null);
@@ -70,30 +167,7 @@ export function CrmActorDocuments({
     queryFn: listObjectDocumentTypes,
   });
 
-  useEffect(() => {
-    let alive = true;
-    const client = getSupabaseClient();
-    if (!client) return;
-    void client.auth.getSession().then(({ data }) => {
-      if (alive) setAccessToken(data.session?.access_token ?? null);
-    });
-    return () => {
-      alive = false;
-    };
-  }, []);
-
   const refresh = () => queryClient.invalidateQueries({ queryKey: ['crm-actor-support', actorId] });
-
-  const uploadMutation = useMutation({
-    mutationFn: async (file: File) => {
-      if (!accessToken) throw new Error('Session expirée. Reconnectez-vous pour ajouter un document.');
-      return uploadActorDocument({ actorId, file, accessToken });
-    },
-    onSuccess: () => {
-      if (fileInputRef.current) fileInputRef.current.value = '';
-      void refresh();
-    },
-  });
 
   const deleteMutation = useMutation({
     mutationFn: async (documentId: string) => {
@@ -145,7 +219,7 @@ export function CrmActorDocuments({
   const canPromote = Boolean(
     promotion && promotion.objectId && selectedPromotionType && promotion.title.trim() && !promoteMutation.isPending,
   );
-  const mutationError = uploadMutation.error ?? deleteMutation.error ?? promoteMutation.error;
+  const mutationError = deleteMutation.error ?? promoteMutation.error;
 
   return (
     <>
@@ -154,31 +228,10 @@ export function CrmActorDocuments({
           <FileText size={15} aria-hidden />
           <h3 id="crm-actor-documents-title">Documents d&apos;accompagnement</h3>
           <span className="crm-actor-docs__count">{documents.length}</span>
-          <button
-            type="button"
-            className="crm-btn sm"
-            disabled={!canWrite || !accessToken || uploadMutation.isPending}
-            title={!canWrite ? CRM_READ_ONLY_REASON : undefined}
-            onClick={() => fileInputRef.current?.click()}
-          >
-            <Upload size={12} aria-hidden /> {uploadMutation.isPending ? 'Ajout…' : 'Ajouter'}
-          </button>
-          <input
-            ref={fileInputRef}
-            className="crm-actor-docs__file-input"
-            type="file"
-            accept="application/pdf,image/jpeg,image/png,image/webp"
-            aria-label="Ajouter un document à l'acteur"
-            onChange={(event) => {
-              const file = event.target.files?.[0];
-              if (file) uploadMutation.mutate(file);
-            }}
-          />
         </div>
         <div className="crm-panel__body crm-actor-docs__body">
           <p className="crm-actor-docs__intro">
             Espace privé pour réunir les pièces du projet avant la création ou le rattachement à un établissement.
-            Les images sont optimisées à 2 000 px maximum (ratio conservé) et les PDF limités à 5 Mo.
           </p>
           {supportQuery.isLoading && <p className="crm-rail__empty">Chargement des documents…</p>}
           {supportQuery.isError && <div className="inline-alert">{errorMessage(supportQuery.error)}</div>}

--- a/bertel-tourism-ui/src/features/crm/CrmActorFiche.test.tsx
+++ b/bertel-tourism-ui/src/features/crm/CrmActorFiche.test.tsx
@@ -123,15 +123,29 @@ beforeEach(() => {
 });
 
 describe('CrmActorFiche (§61 — fiche acteur 360°)', () => {
-  it('affiche la bibliothèque documentaire et le rôle par défaut d’un acteur sans établissement', async () => {
+  it('affiche la bibliothèque dans un onglet dédié et la drop zone dans le rail droit', async () => {
     crmMock.listActorCrm.mockResolvedValue({ ...snapshot, objects: [] });
     crmMock.listActorSupport.mockResolvedValue({ defaultRole: { code: 'guide', name: 'Guide' }, documents: [] });
 
     renderFiche();
 
-    expect(await screen.findByRole('heading', { name: "Documents d'accompagnement" })).toBeInTheDocument();
     expect(await screen.findByText('Guide')).toBeInTheDocument();
+    const activityTab = screen.getByRole('tab', { name: 'Activité' });
+    const documentsTab = screen.getByRole('tab', { name: /Documents d'accompagnement/ });
+    expect(activityTab).toHaveAttribute('aria-selected', 'true');
+    expect(documentsTab).toHaveAttribute('aria-selected', 'false');
+    expect(screen.queryByRole('heading', { name: "Documents d'accompagnement" })).not.toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByRole('tablist', { name: 'Sections de la fiche acteur' }), { key: 'ArrowRight' });
+
+    expect(documentsTab).toHaveAttribute('aria-selected', 'true');
+    const main = document.querySelector('.crm-actor-grid__main') as HTMLElement;
+    const side = document.querySelector('.crm-actor-grid__side') as HTMLElement;
+    expect(within(main).getByRole('heading', { name: "Documents d'accompagnement" })).toBeInTheDocument();
     expect(screen.getByText('Aucun document pour le moment.')).toBeInTheDocument();
+    expect(within(side).getByRole('heading', { name: 'Ajouter un document' })).toBeInTheDocument();
+    expect(within(side).getByRole('button', { name: /Déposez un fichier ici/ })).toHaveClass('crm-actor-docs-dropzone');
+    expect(within(side).queryByText('Interactions · 12 mois')).not.toBeInTheDocument();
   });
 
   it('rend la carte acteur (rôles distincts en sous-ligne), les établissements liés et le badge principal', async () => {

--- a/bertel-tourism-ui/src/features/crm/CrmActorFiche.tsx
+++ b/bertel-tourism-ui/src/features/crm/CrmActorFiche.tsx
@@ -18,7 +18,7 @@
 // Gating page-wide write_crm_notes : boutons désactivés AVEC raison (no-write-trap).
 // Gate `canWrite` fourni par l'hôte (page-wide sur /crm ; per-objet dans le tiroir éditeur).
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type KeyboardEvent } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Building2, CalendarPlus, ChevronDown, ChevronLeft, Globe, Link2, MapPin, Mail, Pencil, Phone, Plus } from 'lucide-react';
 import {
@@ -36,7 +36,7 @@ import { CrmInteractionModal } from './CrmInteractionModal';
 import { CrmModal } from './CrmModal';
 import { CrmTaskModal } from './CrmTaskModal';
 import { CrmActorEditModal } from './CrmActorModals';
-import { CrmActorDocuments } from './CrmActorDocuments';
+import { CrmActorDocumentDropzone, CrmActorDocuments } from './CrmActorDocuments';
 import { SkeletonBlock } from '../../components/common/SkeletonBlock';
 import { CRM_READ_ONLY_REASON, channelHrefOf, formatShort, topicTintOf } from './crm-view-utils';
 
@@ -69,6 +69,7 @@ function errorMessageOf(error: unknown): string {
 }
 
 type FicheModal = 'interaction' | 'task' | 'edit' | 'assign' | null;
+type FicheTab = 'activity' | 'documents';
 
 /**
  * Modal « Affecter un établissement » (§66) — rattache l'acteur à un établissement EXISTANT de
@@ -316,6 +317,7 @@ export function CrmActorFiche({
 
   // 'all' | 'general' | <objectId> — filtre de contexte de la timeline.
   const [ctxFilter, setCtxFilter] = useState<string>('all');
+  const [activeTab, setActiveTab] = useState<FicheTab>('activity');
   const [modal, setModal] = useState<FicheModal>(null);
   // Repli mobile (rectif PO §66+) : sur petit écran, seule la carte acteur est visible ; ce toggle
   // déplie KPI + Établissements + Sujets. Défaut REPLIÉ (mobile). Au-dessus du breakpoint, une media
@@ -421,90 +423,147 @@ export function CrmActorFiche({
   const linkedRoles = [...new Set(objects.map((object) => object.roleName).filter(Boolean))].join(' · ');
   const identitySubline = linkedRoles || supportQuery.data?.defaultRole?.name || '';
 
+  function handleTabKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    let nextTab: FicheTab | null = null;
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+      nextTab = activeTab === 'activity' ? 'documents' : 'activity';
+    } else if (event.key === 'Home') {
+      nextTab = 'activity';
+    } else if (event.key === 'End') {
+      nextTab = 'documents';
+    }
+    if (!nextTab) return;
+    event.preventDefault();
+    setActiveTab(nextTab);
+    document.getElementById(`crm-actor-tab-${nextTab}`)?.focus();
+  }
+
   return (
     <div className="crm-body">
       <button type="button" className="crm-back" onClick={onBack}>
         <ChevronLeft size={12} aria-hidden /> {backLabel}
       </button>
 
+      <div
+        className="crm-actor-tabs"
+        role="tablist"
+        aria-label="Sections de la fiche acteur"
+        onKeyDown={handleTabKeyDown}
+      >
+        <button
+          id="crm-actor-tab-activity"
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'activity'}
+          aria-controls="crm-actor-panel-activity"
+          tabIndex={activeTab === 'activity' ? 0 : -1}
+          className={activeTab === 'activity' ? 'is-on' : ''}
+          onClick={() => setActiveTab('activity')}
+        >
+          Activité
+        </button>
+        <button
+          id="crm-actor-tab-documents"
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'documents'}
+          aria-controls="crm-actor-panel-documents"
+          tabIndex={activeTab === 'documents' ? 0 : -1}
+          className={activeTab === 'documents' ? 'is-on' : ''}
+          onClick={() => setActiveTab('documents')}
+        >
+          Documents d&apos;accompagnement
+          <span className="n">{supportQuery.data?.documents.length ?? 0}</span>
+        </button>
+      </div>
+
       {/* Deux colonnes (rectif PO) : main (actions + timeline) à GAUCHE, rail (acteur + KPI + listes)
           à DROITE. Sur mobile la grille s'effondre en 1 colonne avec le rail (order: -1) AVANT la
           colonne main — voir styles.css .crm-actor-grid. */}
-      <div className="crm-actor-grid">
+      <div
+        id={`crm-actor-panel-${activeTab}`}
+        className="crm-actor-grid"
+        role="tabpanel"
+        aria-labelledby={`crm-actor-tab-${activeTab}`}
+      >
         <div className="crm-actor-grid__main">
-          {!canWrite && <p className="crm-readonly-note">{CRM_READ_ONLY_REASON}</p>}
-          {/* Actions en tête de la colonne principale. */}
-          <div className="crm-actor-actions">
-            <button
-              type="button"
-              className="crm-btn"
-              disabled={!canWrite || !hasEstablishment}
-              title={!canWrite ? CRM_READ_ONLY_REASON : !hasEstablishment ? NO_ESTABLISHMENT_REASON : undefined}
-              onClick={() => setModal('task')}
-            >
-              <CalendarPlus size={13} aria-hidden /> Nouvelle tâche
-            </button>
-            <button
-              type="button"
-              className="crm-btn primary"
-              disabled={!canWrite || !hasEstablishment}
-              title={!canWrite ? CRM_READ_ONLY_REASON : !hasEstablishment ? NO_ESTABLISHMENT_REASON : undefined}
-              onClick={() => setModal('interaction')}
-            >
-              <Plus size={13} aria-hidden /> Nouvelle interaction
-            </button>
-          </div>
-
-          <CrmActorDocuments
-            actorId={actorId}
-            canWrite={canWrite}
-            objects={objects.map((object) => ({ objectId: object.objectId, objectName: object.objectName }))}
-          />
-
-          <div className="crm-panel">
-            <div className="crm-panel__body">
-              <div className="chip-row crm-ctx-filters" role="group" aria-label="Filtrer par contexte">
+          {activeTab === 'activity' ? (
+            <>
+              {!canWrite && <p className="crm-readonly-note">{CRM_READ_ONLY_REASON}</p>}
+              {/* Actions en tête de la colonne principale. */}
+              <div className="crm-actor-actions">
                 <button
                   type="button"
-                  className={'crm-chip' + (ctxFilter === 'all' ? ' is-on' : '')}
-                  aria-pressed={ctxFilter === 'all'}
-                  onClick={() => setCtxFilter('all')}
+                  className="crm-btn"
+                  disabled={!canWrite || !hasEstablishment}
+                  title={!canWrite ? CRM_READ_ONLY_REASON : !hasEstablishment ? NO_ESTABLISHMENT_REASON : undefined}
+                  onClick={() => setModal('task')}
                 >
-                  Tous
+                  <CalendarPlus size={13} aria-hidden /> Nouvelle tâche
                 </button>
-                {objects.map((object) => (
-                  <button
-                    key={object.objectId}
-                    type="button"
-                    className={'crm-chip' + (ctxFilter === object.objectId ? ' is-on' : '')}
-                    aria-pressed={ctxFilter === object.objectId}
-                    onClick={() => setCtxFilter(object.objectId)}
-                  >
-                    {object.objectName}
-                  </button>
-                ))}
                 <button
                   type="button"
-                  className={'crm-chip' + (ctxFilter === 'general' ? ' is-on' : '')}
-                  aria-pressed={ctxFilter === 'general'}
-                  onClick={() => setCtxFilter('general')}
+                  className="crm-btn primary"
+                  disabled={!canWrite || !hasEstablishment}
+                  title={!canWrite ? CRM_READ_ONLY_REASON : !hasEstablishment ? NO_ESTABLISHMENT_REASON : undefined}
+                  onClick={() => setModal('interaction')}
                 >
-                  Général
+                  <Plus size={13} aria-hidden /> Nouvelle interaction
                 </button>
               </div>
 
-              <CrmTimeline
-                items={timelineItems}
-                onOpenObject={onOpenObject}
-                canWrite={canWrite}
-                readOnlyReason={CRM_READ_ONLY_REASON}
-                onReply={handleReply}
-                onResolve={handleResolve}
-                onEditInteraction={handleEditInteraction}
-                onDeleteInteraction={handleDeleteInteraction}
-              />
-            </div>
-          </div>
+              <div className="crm-panel">
+                <div className="crm-panel__body">
+                  <div className="chip-row crm-ctx-filters" role="group" aria-label="Filtrer par contexte">
+                    <button
+                      type="button"
+                      className={'crm-chip' + (ctxFilter === 'all' ? ' is-on' : '')}
+                      aria-pressed={ctxFilter === 'all'}
+                      onClick={() => setCtxFilter('all')}
+                    >
+                      Tous
+                    </button>
+                    {objects.map((object) => (
+                      <button
+                        key={object.objectId}
+                        type="button"
+                        className={'crm-chip' + (ctxFilter === object.objectId ? ' is-on' : '')}
+                        aria-pressed={ctxFilter === object.objectId}
+                        onClick={() => setCtxFilter(object.objectId)}
+                      >
+                        {object.objectName}
+                      </button>
+                    ))}
+                    <button
+                      type="button"
+                      className={'crm-chip' + (ctxFilter === 'general' ? ' is-on' : '')}
+                      aria-pressed={ctxFilter === 'general'}
+                      onClick={() => setCtxFilter('general')}
+                    >
+                      Général
+                    </button>
+                  </div>
+
+                  <CrmTimeline
+                    items={timelineItems}
+                    onOpenObject={onOpenObject}
+                    canWrite={canWrite}
+                    readOnlyReason={CRM_READ_ONLY_REASON}
+                    onReply={handleReply}
+                    onResolve={handleResolve}
+                    onEditInteraction={handleEditInteraction}
+                    onDeleteInteraction={handleDeleteInteraction}
+                  />
+                </div>
+              </div>
+            </>
+          ) : (
+            <CrmActorDocuments
+              actorId={actorId}
+              canWrite={canWrite}
+              objects={objects.map((object) => ({ objectId: object.objectId, objectName: object.objectName }))}
+            />
+          )}
         </div>
 
         <aside className="crm-actor-grid__side crm-rail" aria-label="Synthèse de l'acteur">
@@ -519,24 +578,28 @@ export function CrmActorFiche({
             onEdit={() => setModal('edit')}
           />
 
-          {/* Toggle MOBILE-ONLY (masqué ≥ breakpoint par media query) : déplie KPI + listes. */}
-          <button
-            type="button"
-            className="crm-actor-side-toggle"
-            aria-expanded={sideExpanded}
-            aria-controls="crm-actor-side-collapsible"
-            onClick={() => setSideExpanded((open) => !open)}
-          >
-            {sideExpanded ? 'Masquer les indicateurs' : 'Voir les indicateurs'}
-            <ChevronDown size={13} aria-hidden className={'chev' + (sideExpanded ? ' is-open' : '')} />
-          </button>
+          {activeTab === 'documents' ? (
+            <CrmActorDocumentDropzone actorId={actorId} canWrite={canWrite} />
+          ) : (
+            <>
+              {/* Toggle MOBILE-ONLY (masqué ≥ breakpoint par media query) : déplie KPI + listes. */}
+              <button
+                type="button"
+                className="crm-actor-side-toggle"
+                aria-expanded={sideExpanded}
+                aria-controls="crm-actor-side-collapsible"
+                onClick={() => setSideExpanded((open) => !open)}
+              >
+                {sideExpanded ? 'Masquer les indicateurs' : 'Voir les indicateurs'}
+                <ChevronDown size={13} aria-hidden className={'chev' + (sideExpanded ? ' is-open' : '')} />
+              </button>
 
-          {/* Région repliable : KPI + Établissements + Sujets. Sur mobile l'état JS pilote
-              l'affichage ; ≥ breakpoint la media query la force visible (is-open ignoré). */}
-          <div
-            id="crm-actor-side-collapsible"
-            className={'crm-actor-collapsible' + (sideExpanded ? ' is-open' : '')}
-          >
+              {/* Région repliable : KPI + Établissements + Sujets. Sur mobile l'état JS pilote
+                  l'affichage ; ≥ breakpoint la media query la force visible (is-open ignoré). */}
+              <div
+                id="crm-actor-side-collapsible"
+                className={'crm-actor-collapsible' + (sideExpanded ? ' is-open' : '')}
+              >
             {/* KPI compacts (rectif PO §66+) — 4 accents cyclés teal / orange / bleu / prune.
                Sans légende : les chiffres/dates se suffisent ; les captions doublonnaient l'en-tête (rectif PO). */}
             <div className="crm-actor-kpis">
@@ -584,7 +647,9 @@ export function CrmActorFiche({
                 </div>
               </div>
             )}
-          </div>
+              </div>
+            </>
+          )}
         </aside>
       </div>
 

--- a/bertel-tourism-ui/src/styles.css
+++ b/bertel-tourism-ui/src/styles.css
@@ -11635,6 +11635,53 @@ a {
 .crm-app .crm-actor-grid__main { min-width: 0; display: flex; flex-direction: column; gap: 14px; }
 .crm-app .crm-actor-grid__side { min-width: 0; }
 
+/* Navigation interne de la fiche : la bibliothèque documentaire est une vue dédiée. */
+.crm-app .crm-actor-tabs {
+  display: flex;
+  align-items: flex-end;
+  gap: 22px;
+  margin-bottom: 14px;
+  padding: 0 2px;
+  border-bottom: 1px solid var(--line-soft);
+  overflow-x: auto;
+}
+.crm-app .crm-actor-tabs button {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 38px;
+  margin-bottom: -1px;
+  padding: 0 2px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--ink-3);
+  font-family: inherit;
+  font-size: 12.5px;
+  font-weight: 650;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.crm-app .crm-actor-tabs button:hover { color: var(--ink); }
+.crm-app .crm-actor-tabs button.is-on { border-bottom-color: var(--accent); color: var(--accent-deep); }
+.crm-app .crm-actor-tabs button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px 4px 0 0;
+}
+.crm-app .crm-actor-tabs .n {
+  min-width: 20px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--ink-4);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 18px;
+  text-align: center;
+}
+.crm-app .crm-actor-tabs button.is-on .n { background: var(--bg-tint); color: var(--accent-deep); }
+
 /* Rangée d'actions en tête de la colonne principale (« Nouvelle tâche » / « Nouvelle interaction »). */
 .crm-app .crm-actor-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 
@@ -11756,7 +11803,6 @@ a {
   font-size: 10.5px;
   font-weight: 700;
 }
-.crm-app .crm-actor-docs .crm-panel__head .crm-btn { margin-left: auto; }
 .crm-app .crm-actor-docs__file-input { display: none; }
 .crm-app .crm-actor-docs__body { display: flex; flex-direction: column; gap: 12px; }
 .crm-app .crm-actor-docs__intro { margin: 0; color: var(--ink-3); font-size: 12px; line-height: 1.5; }
@@ -11787,6 +11833,41 @@ a {
 .crm-app .crm-actor-docs__meta strong { color: var(--ink); font-size: 12.5px; }
 .crm-app .crm-actor-docs__meta small { margin-top: 2px; color: var(--ink-4); font-size: 10.5px; }
 .crm-app .crm-actor-docs__actions { display: inline-flex; align-items: center; gap: 6px; flex: none; }
+
+/* Ajout documentaire dans le rail droit de l'onglet Documents. */
+.crm-app .crm-actor-docs-upload { display: flex; flex-direction: column; gap: 12px; }
+.crm-app .crm-actor-docs-upload h4 { margin-bottom: 0; }
+.crm-app .crm-actor-docs-dropzone {
+  width: 100%;
+  min-height: 180px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 20px 16px;
+  border: 1.5px dashed var(--line-strong);
+  border-radius: var(--r-md);
+  background: var(--bg-tint);
+  color: var(--accent-deep);
+  font-family: inherit;
+  text-align: center;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+.crm-app .crm-actor-docs-dropzone:hover:not(:disabled),
+.crm-app .crm-actor-docs-dropzone.is-dragging {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent);
+  transform: translateY(-1px);
+}
+.crm-app .crm-actor-docs-dropzone:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.crm-app .crm-actor-docs-dropzone:disabled { cursor: not-allowed; opacity: 0.58; }
+.crm-app .crm-actor-docs-dropzone strong { font-size: 13px; color: var(--ink); }
+.crm-app .crm-actor-docs-dropzone span { font-size: 11.5px; color: var(--ink-3); }
+.crm-app .crm-actor-docs-dropzone small { margin-top: 8px; font-size: 10.5px; line-height: 1.5; color: var(--ink-4); }
+.crm-app .crm-actor-docs-upload .inline-alert { margin: 0; }
 
 @media (max-width: 720px) {
   .crm-app .crm-actor-docs__row { align-items: flex-start; flex-wrap: wrap; }


### PR DESCRIPTION
## Ce qui change

- ajoute les onglets « Activité » et « Documents d’accompagnement » sur la fiche acteur ;
- affiche la galerie documentaire dans la colonne principale de la vue Documents ;
- déplace l’ajout dans une drop zone dédiée du rail droit, avec clic et glisser-déposer ;
- conserve les permissions, la session Supabase et les actions ouvrir, transférer et supprimer ;
- prend en charge la navigation clavier entre les onglets.

## Pourquoi

La galerie occupait en permanence une grande zone au-dessus de la timeline. Cette séparation rend la fiche Activité plus lisible et regroupe les interactions documentaires dans une vue dédiée.

## Impact

L’activité reste la vue par défaut. Dans l’onglet Documents, la carte acteur et la zone d’ajout sont à droite, tandis que la galerie est à gauche.

## Validation

- `npm run test:run -- --runInBand src/features/crm/CrmActorFiche.test.tsx` — 41 tests passés.
- `git diff --check` — aucune erreur.
- Le typecheck global reste bloqué par une erreur préexistante dans `src/services/export/export-actor-contacts.test.ts:58` (`Crypto` vers `Record<string, unknown>`).